### PR TITLE
Use MessageCache to improve label lookup performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,18 @@
-### Version 1.1.0
+### Version 1.1.x
+
+#### 1.1.1
+
+- #25 Added MessageCache to improve registration and lookup performance
+- #33 Added DefinitionReader to separate responsibilities
+
+#### 1.1.0
 
 Released on 2014-04-09
 
 - #31 Fixed error when a User page is created with a subpage
 - #32 Migrate to JSON i18n
 
-#### 1.1.1
-
-- #33 Added DefinitionReader
-
-### Version 1.0
+### Version 1.0.x
 
 Released on 2014-02-23.
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -8,9 +8,17 @@ $GLOBALS['sespSpecialProperties'] = array(
 	...
 );
 ```
-## Property identifier
+## Properties
 
-Property identifiers (see [`definitions.json`](/src/Definition/definitions.json) ) are used to specify which of the properties are enabled. An indentifier is an internal `ID` which is not to be used during user interaction (e.g. handling in `#ask` queries) instead the property label should be used as reference. These labels differ according to the language the wiki was set up. An easy way to identify them is to navigate to special page "Special:Properies" which contains a listing of all available properties inclucding the special properties provided by this extension.
+Property identifiers (see [`definitions.json`](/src/Definition/definitions.json) ) are used to specify which of the properties are enabled. An identifier is an internal `ID` which is not to be used during user interaction (e.g. handling in `#ask` queries) instead the property label should be used as reference.
+
+### Labels
+
+Property labels differ according to the language the wiki was set up. An easy way to identify those used labels is to navigate to the "Special:Properies" page that lists all available properties including properties provided by this extension.
+
+Property labels are displayed in accordance with the maintained [content language][mw-contentlang]. Message keys and labels are retrieved from cache where in case message content is altered (`definitions.json` or message file), the cache will automatically be purged. Changing the default cache type can be achieved by modifying the [`$sespCacheType`][mw-cachetype] customizing.
+
+### Identifier
 
 - `_EUSER` add all users that edited this page (expensive; use with care)
 - `_CUSER` add user that created this page
@@ -77,3 +85,5 @@ can pose a [privacy issue][privacy].
 [data-refresh]: https://semantic-mediawiki.org/wiki/Help:Data_refresh#Examples
 [mw-update]: https://www.mediawiki.org/wiki/Manual:Update.php
 [mw-localsettings]: https://www.mediawiki.org/wiki/Localsettings
+[mw-contentlang]: https://www.mediawiki.org/wiki/Content_language
+[mw-cachetype]: https://www.mediawiki.org/wiki/Manual:$wgMainCacheType

--- a/SemanticExtraSpecialProperties.php
+++ b/SemanticExtraSpecialProperties.php
@@ -71,7 +71,8 @@ $GLOBALS['wgAutoloadClasses']['SESP\BaseAnnotator']            = __DIR__ . '/src
 $GLOBALS['wgAutoloadClasses']['SESP\PropertyRegistry']         = __DIR__ . '/src/PropertyRegistry.php';
 $GLOBALS['wgAutoloadClasses']['SESP\ExifDataAnnotator']        = __DIR__ . '/src/ExifDataAnnotator.php';
 $GLOBALS['wgAutoloadClasses']['SESP\ShortUrlAnnotator']        = __DIR__ . '/src/ShortUrlAnnotator.php';
-$GLOBALS['wgAutoloadClasses']['SESP\Definition\DefinitionReader']        = __DIR__ . '/src/Definition/DefinitionReader.php';
+$GLOBALS['wgAutoloadClasses']['SESP\Definition\DefinitionReader'] = __DIR__ . '/src/Definition/DefinitionReader.php';
+$GLOBALS['wgAutoloadClasses']['SESP\Cache\MessageCache']          = __DIR__ . '/src/Cache/MessageCache.php';
 
 /**
  * Setup and initialization
@@ -79,6 +80,8 @@ $GLOBALS['wgAutoloadClasses']['SESP\Definition\DefinitionReader']        = __DIR
  * @since 1.0
  */
 $GLOBALS['wgExtensionFunctions']['semantic-extra-special-properties'] = function() {
+
+	$GLOBALS['sespCacheType'] = isset( $GLOBALS['sespCacheType'] ) ? $GLOBALS['sespCacheType'] : CACHE_ANYTHING;
 
 	/**
 	 * Collect only relevant configuration parameters

--- a/build/travis/script.sh
+++ b/build/travis/script.sh
@@ -23,7 +23,7 @@ function installSemanticExtraSpecialPropertiesAsExtension {
 	cp -r $originalDirectory SemanticExtraSpecialProperties
 
 	cd SemanticExtraSpecialProperties
-	composer update --prefer-source
+	composer update --prefer-source --dev
 
 	cd ../..
 

--- a/src/Cache/MessageCache.php
+++ b/src/Cache/MessageCache.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace SESP\Cache;
+
+use ObjectCache;
+use Language;
+use BagOStuff;
+
+/**
+ * @ingroup SESP
+ *
+ * @licence GNU GPL v2+
+ * @since 1.1.1
+ *
+ * @author mwjames
+ */
+class MessageCache {
+
+	/** @var Language */
+	protected $language = null;
+
+	protected $touched = null;
+	protected $cacheTimeOffset = null;
+	protected $messages = null;
+	protected $cache = null;
+
+	/**
+	 * @since 1.1.1
+	 *
+	 * @param Language $language
+	 * @param integer|null $cacheTimeOffset
+	 */
+	public function __construct( Language $language, $cacheTimeOffset = null ) {
+		$this->language = $language;
+		$this->cacheTimeOffset = $cacheTimeOffset;
+	}
+
+	/**
+	 * @since 1.1.1
+	 *
+	 * @param Language $language
+	 *
+	 * @return MessageCache
+	 */
+	public static function byLanguage( Language $language ) {
+		return new self( $language );
+	}
+
+	/**
+	 * @since 1.1.1
+	 *
+	 * MessageCache::byLanguage( Language::factory( 'en' ) )->purge()
+	 *
+	 * @return MessageCache
+	 */
+	public function purge() {
+		$this->getCache()->delete( $this->getCacheId() );
+		return $this;
+	}
+
+	/**
+	 * @since 1.1.1
+	 *
+	 * @param integer $cacheTimeOffset
+	 *
+	 * @return MessageCache
+	 */
+	public function setCacheTimeOffset( $cacheTimeOffset ) {
+		$this->cacheTimeOffset = $cacheTimeOffset;
+		return $this;
+	}
+
+	/**
+	 * @since 1.1.1
+	 *
+	 * @param BagOStuff $cache
+	 */
+	public function setCache( BagOStuff $cache ) {
+		$this->cache = $cache;
+		return $this;
+	}
+
+	/**
+	 * @since 1.1.1
+	 *
+	 * @return string
+	 */
+	public function getCacheId() {
+		return $this->getCachePrefix() . ':sesp:mcache:' . $this->language->getCode();
+	}
+
+	/**
+	 * @since 1.1.1
+	 *
+	 * @param string $key
+	 *
+	 * @return string
+	 */
+	public function get( $key /* arguments */ ) {
+
+		$arguments = func_get_args();
+
+		if ( $this->messages === null ) {
+			$this->messages = $this->loadMessagesFromCache();
+		}
+
+		$key = implode( '#', $arguments );
+
+		if ( isset( $this->messages[ $key ] ) ) {
+			return $this->messages[ $key ];
+		}
+
+		return $this->getTextMessage( $key, $arguments );
+	}
+
+	protected function getTextMessage( $key, $arguments ) {
+
+		$this->messages[ $key ] = wfMessage( $arguments )->inLanguage( $this->language )->text();
+		$this->updateMessagesToCache();
+
+		return $this->messages[ $key ];
+	}
+
+	protected function updateMessagesToCache() {
+
+		$messagesToBeCached = array(
+			'touched'  => $this->getTouched(),
+			'messages' => $this->messages
+		);
+
+		return $this->getCache()->set( $this->getCacheId(), $messagesToBeCached );
+	}
+
+	protected function loadMessagesFromCache() {
+
+		$cached = $this->getCache()->get( $this->getCacheId() );
+
+		if ( isset( $cached['touched'] ) && isset( $cached['messages'] ) && $cached['touched'] === $this->getTouched() ) {
+			return $cached['messages'];
+		}
+
+		return null;
+	}
+
+	protected function getCache() {
+
+		if ( !$this->cache instanceOf BagOStuff ) {
+			$this->cache = ObjectCache::getInstance( $GLOBALS['sespCacheType'] );
+		}
+
+		return $this->cache;
+	}
+
+	protected function getCachePrefix() {
+		return $GLOBALS['wgCachePrefix'] === false ? wfWikiID() : $GLOBALS['wgCachePrefix'];
+	}
+
+	protected function getTouched() {
+
+		if ( $this->touched === null ) {
+			$this->touched = $this->getMessageFileModificationTime() . $this->cacheTimeOffset;
+		}
+
+		return $this->touched;
+	}
+
+	protected function getMessageFileModificationTime() {
+
+		if ( method_exists( $this->language, 'getJsonMessagesFileName' )  ) {
+			return filemtime( $this->language->getJsonMessagesFileName( $this->language->getCode() ) );
+		}
+
+		return filemtime( $this->language->getMessagesFileName( $this->language->getCode() ) );
+	}
+
+}

--- a/src/Definition/DefinitionReader.php
+++ b/src/Definition/DefinitionReader.php
@@ -41,22 +41,31 @@ class DefinitionReader {
 		}
 
 		if ( $this->definitions === null ) {
-			$this->definitions = $this->acquireDefinitionsFromJsonFile( $this->definitionFile );
+			$this->definitions = $this->decodeJsonFile( $this->isReadableOrThrowException( $this->definitionFile ) );
 		}
 
 		return $this->definitions;
+	}
+
+	/**
+	 * @since 1.1.1
+	 *
+	 * @return integer
+	 */
+	public function getModificationTime() {
+		return filemtime( $this->isReadableOrThrowException( $this->getDefaultDefinitionFile() ) );
 	}
 
 	protected function getDefaultDefinitionFile() {
 		return __DIR__ . '/' . 'definitions.json';
 	}
 
-	protected function acquireDefinitionsFromJsonFile( $definitionFile ) {
+	protected function isReadableOrThrowException( $definitionFile ) {
 
 		$definitionFile = str_replace( array( '\\', '/' ), DIRECTORY_SEPARATOR, $definitionFile );
 
 		if ( is_readable( $definitionFile ) ) {
-			return $this->decodeJsonFile( $definitionFile );
+			return $definitionFile;
 		}
 
 		throw new RuntimeException( "Expected a {$definitionFile} file" );

--- a/tests/phpunit/Integration/HookRegistrationIntegrationTest.php
+++ b/tests/phpunit/Integration/HookRegistrationIntegrationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SESP\Tests;
+namespace SESP\Tests\Integration;
 
 use SESP\PropertyRegistry;
 use SMW\SemanticData;
@@ -23,9 +23,36 @@ use Title;
  */
 class HookRegistrationIntegrationTest extends \PHPUnit_Framework_TestCase {
 
+	protected $sespCacheType = null;
+	protected $wgHooks = array();
+	protected $wgExtensionFunctions = array();
+
+	protected function setUp() {
+
+		// Clears all GLOBALS that can influence the test run
+		$this->wgHooks = $GLOBALS['wgHooks'];
+		$this->wgExtensionFunctions = $GLOBALS['wgExtensionFunctions'];
+		$this->sespCacheType = $GLOBALS['sespCacheType'];
+
+		// Set default values used during the test run
+		$GLOBALS['wgHooks'] = array();
+		$GLOBALS['wgExtensionFunctions'] = array();
+		$GLOBALS['sespCacheType'] = 'hash';
+
+		parent::setUp();
+	}
+
+	protected function tearDown() {
+		parent::tearDown();
+
+		$GLOBALS['sespCacheType'] = $this->sespCacheType;
+		$GLOBALS['wgHooks'] = $this->wgHooks;
+		$GLOBALS['wgExtensionFunctions'] = $this->wgExtensionFunctions;
+	}
+
 	public function testExtensionHookRegistration() {
 
-		$registry = $GLOBALS['wgExtensionFunctions']['semantic-extra-special-properties'];
+		$registry = $this->wgExtensionFunctions['semantic-extra-special-properties'];
 
 		$this->assertTrue( is_callable( $registry ) );
 		$this->assertTrue( call_user_func( $registry) );
@@ -35,6 +62,8 @@ class HookRegistrationIntegrationTest extends \PHPUnit_Framework_TestCase {
 	 * @depends testExtensionHookRegistration
 	 */
 	public function testInitPropertiesHookToFetchPropertyTypeId() {
+
+		$this->callExtensionFunctions();
 
 		$propertyId = PropertyRegistry::getInstance()->getPropertyId( '_REVID' );
 
@@ -49,6 +78,8 @@ class HookRegistrationIntegrationTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testStoreUpdateHookInterfaceInitialization() {
 
+		$this->callExtensionFunctions();
+
 		$semanticData = new SemanticData(
 			DIWikiPage::newFromTitle( Title::newFromText( __METHOD__ ) )
 		);
@@ -57,6 +88,13 @@ class HookRegistrationIntegrationTest extends \PHPUnit_Framework_TestCase {
 		StoreFactory::getStore()->updateData( $semanticData );
 
 		$this->assertTrue( true );
+	}
+
+	protected function callExtensionFunctions() {
+		call_user_func_array(
+			$this->wgExtensionFunctions['semantic-extra-special-properties'],
+			array()
+		);
 	}
 
 }

--- a/tests/phpunit/Unit/Cache/MessageCacheTest.php
+++ b/tests/phpunit/Unit/Cache/MessageCacheTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace SESP\Tests\Cache;
+
+use SESP\Cache\MessageCache;
+
+use Language;
+use HashBagOStuff;
+
+/**
+ * @covers \SESP\Cache\MessageCache
+ *
+ * @ingroup Test
+ *
+ * @group SESP
+ * @group SESPExtension
+ * @group mediawiki-databaseless
+ *
+ * @license GNU GPL v2+
+ * @since 1.1.1
+ *
+ * @author mwjames
+ */
+class MessageCacheTest extends \PHPUnit_Framework_TestCase {
+
+	protected $cacheId = 'sesp:foo';
+
+	public function testCanConstruct() {
+
+		$language = $this->getMockBuilder( 'Language' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$touched = 1000;
+
+		$this->assertInstanceOf(
+			'\SESP\Cache\MessageCache',
+			new MessageCache( $language, $touched )
+		);
+	}
+
+	public function testAccessibility() {
+
+		$instance = new MessageCache(
+			Language::factory( 'en' ),
+			10001
+		);
+
+		$instance->setCache( new HashBagOStuff );
+		$this->assertInternalType( 'string', $instance->get( 'foo' ) );
+	}
+
+	public function testAddNewCachedMessage() {
+
+		$cache = new HashBagOStuff;
+
+		$instance = $this->acquireInstanceWith( 1000 );
+		$instance->setCache( $cache );
+
+		$this->assertFalse( $cache->get( $this->cacheId ) );
+
+		$this->assertInternalType( 'string', $instance->get( 'exif-software' ) );
+		$this->assertInternalType( 'array', $cache->get( $this->cacheId ) );
+
+		$this->assertArrayHasKey( 'touched', $cache->get( $this->cacheId ) );
+		$this->assertArrayHasKey( 'messages', $cache->get( $this->cacheId ) );
+	}
+
+	public function testGetCachedMessage() {
+
+		$cacheTimeOffset = 9999;
+
+		$cache = new HashBagOStuff;
+
+		$presetCached = array(
+			'touched'  => $cacheTimeOffset . 1000,
+			'messages' => array( 'foo' => 'bar' )
+		);
+
+		$cache->set( $this->cacheId, $presetCached );
+
+		$instance = $this->acquireInstanceWith( 1000, $cacheTimeOffset );
+		$instance->setCache( $cache );
+
+		$this->assertEquals( 'bar', $instance->get( 'foo' ) );
+	}
+
+	public function testCachePurgeByLanguage() {
+
+		$cache = new HashBagOStuff;
+
+		$instanceJa = MessageCache::byLanguage( Language::factory( 'ja' ) );
+		$instanceEn = MessageCache::byLanguage( Language::factory( 'en' ) );
+
+		$presetCached = array(
+			'touched'  => 1000,
+			'messages' => array( 'foo' => 'bar' )
+		);
+
+		$cache->set( $instanceEn->getCacheId(), $presetCached );
+		$cache->set( $instanceJa->getCacheId(), $presetCached );
+
+		$instanceEn->setCache( $cache )->purge();
+		$instanceJa->setCache( $cache );
+
+		$this->assertEmpty( $cache->get( $instanceEn->getCacheId() ) );
+		$this->assertNotEmpty( $cache->get( $instanceJa->getCacheId() ) );
+	}
+
+	protected function acquireInstanceWith( $modificationTimeOffset, $cacheTimeOffset = null ) {
+
+		$language = Language::factory( 'en' );
+
+		$instance = $this->getMock( '\SESP\Cache\MessageCache',
+			array(
+				'getCacheId',
+				'getMessageFileModificationTime' ),
+			array(
+				$language,
+				$modificationTimeOffset )
+		);
+
+		$instance->expects( $this->atLeastOnce() )
+			->method( 'getCacheId' )
+			->will( $this->returnValue( $this->cacheId ) );
+
+		$instance->expects( $this->atLeastOnce() )
+			->method( 'getMessageFileModificationTime' )
+			->will( $this->returnValue( $cacheTimeOffset ) );
+
+		return $instance;
+	}
+
+}

--- a/tests/phpunit/Unit/Definition/DefinitionReaderTest.php
+++ b/tests/phpunit/Unit/Definition/DefinitionReaderTest.php
@@ -32,6 +32,11 @@ class DefinitionReaderTest extends \PHPUnit_Framework_TestCase {
 		$this->assertInternalType( 'array', $instance->getDefinitions() );
 	}
 
+	public function testGetModificationTime() {
+		$instance = new DefinitionReader;
+		$this->assertInternalType( 'integer', $instance->getModificationTime() );
+	}
+
 	public function testInaccessibleJsonFileThrowsExeception() {
 
 		$this->setExpectedException( 'RuntimeException' );

--- a/tests/phpunit/Unit/PropertyRegistryTest.php
+++ b/tests/phpunit/Unit/PropertyRegistryTest.php
@@ -17,12 +17,26 @@ use ReflectionClass;
  * @group SESPExtension
  * @group mediawiki-databaseless
  *
- * @licence GNU GPL v2+
+ * @license GNU GPL v2+
  * @since 1.0
  *
  * @author mwjames
  */
 class PropertyRegistryTest extends \PHPUnit_Framework_TestCase {
+
+	protected $sespCacheType = null;
+
+	protected function setUp() {
+		$this->sespCacheType = $GLOBALS['sespCacheType'];
+		$GLOBALS['sespCacheType'] = 'hash';
+
+		parent::setUp();
+	}
+
+	protected function tearDown() {
+		parent::tearDown();
+		$GLOBALS['sespCacheType'] = $this->sespCacheType;
+	}
 
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
@@ -165,7 +179,8 @@ class PropertyRegistryTest extends \PHPUnit_Framework_TestCase {
 			)
 		);
 
-		$property = $this->registerPropertyWithDefinition( $propertydefinition );
+		$propertyId = $this->registerPropertyIdWithDefinition( '_FOOOOO', $propertydefinition );
+		$property = new DIProperty( $propertyId );
 
 		$this->assertInstanceOf( '\SMW\DIProperty', $property );
 		$this->assertTrue( $property->isShown() );
@@ -183,13 +198,63 @@ class PropertyRegistryTest extends \PHPUnit_Framework_TestCase {
 			)
 		);
 
-		$property = $this->registerPropertyWithDefinition( $propertydefinition );
+		$propertyId = $this->registerPropertyIdWithDefinition( '_FOOOOO', $propertydefinition );
+		$property = new DIProperty( $propertyId );
 
 		$this->assertInstanceOf( '\SMW\DIProperty', $property );
 		$this->assertFalse( $property->isShown() );
 	}
 
-	protected function registerPropertyWithDefinition( $propertydefinition ) {
+	public function testPropertyWithoutMsgKey() {
+
+		$propertydefinition = array(
+			'_EXIF' => array(),
+			'_FOOOOO'  => array(
+				'id'     => '___FOOOOO',
+				'type'   => 1
+			)
+		);
+
+		$propertyId = $this->registerPropertyIdWithDefinition( '_FOOOOO', $propertydefinition );
+		$property = new DIProperty( $propertyId );
+
+		$this->assertInstanceOf( '\SMW\DIProperty', $property );
+	}
+
+/* FIXME see SMW::core a7db2039c513751ab357c49b87041f2d167f0161
+	public function testPropertyWithInvalidType() {
+
+		$propertydefinition = array(
+			'_EXIF' => array(),
+			'_FOOOOO'  => array(
+				'id'     => '___FOOOOO',
+				'type'   => 9999
+			)
+		);
+
+		$propertyId = $this->registerPropertyIdWithDefinition( '_FOOOOO', $propertydefinition );
+		$property = new DIProperty( $propertyId );
+
+		$this->assertInstanceOf( '\SMW\DIProperty', $property );
+	}
+*/
+
+	public function testPropertyWithoutType() {
+
+		$propertydefinition = array(
+			'_EXIF' => array(),
+			'_FOOOOO'  => array(
+				'id'     => '___FOOOOO'
+			)
+		);
+
+		$propertyId = $this->registerPropertyIdWithDefinition( '_FOOOOO', $propertydefinition );
+		$property = new DIProperty( $propertyId );
+
+		$this->assertInstanceOf( '\SMW\DIProperty', $property );
+	}
+
+	protected function registerPropertyIdWithDefinition( $id, $propertydefinition ) {
 
 		$instance = PropertyRegistry::getInstance();
 
@@ -200,10 +265,10 @@ class PropertyRegistryTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertTrue( $instance->registerPropertiesAndAliases() );
 
-		$property = new DIProperty( $instance->getPropertyId( '_FOOOOO' ) );
+		$propertyId = $instance->getPropertyId( $id );
 		$instance->clear();
 
-		return $property;
+		return $propertyId;
 	}
 
 }


### PR DESCRIPTION
Each single wfMessage call costs around 23ms (using Xdebug profiling) which means that when all properties are registered, wfMessage accounts for up-to 2/3 of the overall the processing/computing
(600ms+) time.

This PR introduces a simple MessageCache (wfMessage uses itself a MessageCache but still runs with 20-35ms per call) which allows to minimize the registration time to under 50ms (~0.5 per property).

As soon as the content language changes or the `json` file is being modified the cache becomes invalid.
