### PR TITLE
Make the 1.4.0 release

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,40 +1,65 @@
 This file contains the RELEASE-NOTES of the SemanticExtraSpecialProperties (a.k.a. SESP) extension.
 
-### 1.4.0 (2016-06-??)
+### 1.4.0
 
-* #54 Guard against `Invalid or virtual namespace -1` exception
-* #59 Fixed `0` annotation values
+Released on January 21, 2017.
+
+This release now requires MediaWiki 1.25+ and Semantic MediaWiki 2.3+ (#61).
+
+* #47 Fixed support for the `_VIEWS` special property for MediaWiki 1.25+ which now requires the HitCounters extension (by Cindy Cicalese)
+* #54 Fixed `Invalid or virtual namespace -1` exception (by James Hong Kong)
+* #55 Fixed `NS_MEDIA` being detected instead of `NS_FILE` (by James Hong Kong)
+* #57 Fixed issue with Composer when run locally (by Cindy Cicalese)
+* #58 Adjusted lang.dep aliases
+* #59 Fixed `0` annotation values (by James Hong Kong)
+* #60 Fixed isse when stat failed for `filemtime():` (by James Hong Kong)
+* #67 Fixed unserialize error in `ExifDataAnnotator` (by James Hong Kong)
+* Several internal code changes (by James Hong Kong and Jeroen De Dauw)
 * Localization updates from https://translatewiki.net
 
-### 1.3.1 (2015-07-18)
+### 1.3.1
+
+Released on July 18, 2015.
 
 - #50 Fixed error with `_USEREDITCNT` on subpages in namespace "user"
 
-### 1.3.0 (2015-05-09)
+### 1.3.0
+
+Released on May 9, 2015.
 
 - #43 Added `_USEREDITCNT` for user edit count collection on user pages
 
-### 1.2.2 (2014-12-31)
+### 1.2.2
+
+Released on December 31, 2014.
 
 - #42 Fixed fatal during `importDump` for when a file doesn't exist
 
-### 1.2.1 (2014-07-21)
+### 1.2.1
+
+Released on July 21, 2014.
 
 - Added compatibility with Semantic MediaWiki 2.x
 
-### 1.2.0 (2014-04-23)
+### 1.2.0
+
+Released on April 23, 2014.
 
 - #25 Added MessageCache to improve registration and lookup performance
 - #33 Added DefinitionReader to separate responsibilities
 
-### 1.1.0 (2014-04-09)
+### 1.1.0
+
+Released on April 9, 2014.
 
 - #31 Fixed error when a User page is created with a subpage
 - #32 Migrate to JSON i18n
 
-### 1.0.0 (2014-02-23)
+### 1.0.0
 
-1.0 is a complete rewrite of the existing implementation to allow sufficient test integration which made it necessary
+Released on February 23, 2014.
+
+Version 1.0 is a complete rewrite of the existing implementation to allow sufficient test integration which made it necessary
 to split the original file into different classes (force encapsulation), eliminate GLOBALS (where necessary inject
 configuration via the constructor), and enable service injection (increase inversion of control).
 
@@ -62,53 +87,70 @@ For details about the rewrite, its discussion, and changes see #10.
 - #20 Added possibility to alter property visibility via the definitions file
 - #21 Extended Exif property definitions
 
-### 0.2.7 (2012-10-22)
+### 0.2.7
+
+Released on October 22, 2012.
 
 - Requires MediaWiki 1.20
 - Use WikiPage instead of Article
 
-### 0.2.6 (2012-10-05)
+### 0.2.6
+
+Released on October 5, 2012.
 
 - Fixed bug sometimes causing a crash on pagesave on MW 1.20+
-- Added `_USERREG`
+- Added `_USERREG` special property
 
-### 0.2.5 (2012-08-01)
+### 0.2.5
+
+Released on August 1, 2012.
 
 - Bugfixes
 - Error message fixes by Nischayn22
 
-### 0.2.4 (2012-07-28)
+### 0.2.4
+
+Released on July 28, 2012.
 
 - Requires MediaWiki 1.19
-- Add some image meta data (exif) properties
+- Added some image meta data (exif) properties
 - Bug fix by Van de Bugger
 
-### 0.2.3 (2012-05-10)
+### 0.2.3
 
-- add `_SHORTURL`
+Released on May 10, 2012.
+
+- Added `_SHORTURL` special property
 - Translation updates, German
 - Fix for bug with first author for certain special pages, by Van de Bugger
 
-### 0.2.2 (2012-02-09)
+### 0.2.2
+
+Released on February 9, 2012.
 
 - $smwgPageSpecialProperties replaced by `$sespSpecialProperties`
-- Added `_MIMETYPE` (mime type, mediatype)
+- Added `_MIMETYPE` (mime type, mediatype) special property
 
-### 0.2.1 (2012-01-08)
+### 0.2.1
+
+Released on January 8, 2012.
 
 - German translation by Kghbln
-- Better method to fetch list of `_EUSER` (getContributors and getUser, instead of getLastNAuthors. Anonymous users
-will never be listed)
+- Better method to fetch list of `_EUSER` (getContributors and getUser, instead of getLastNAuthors. Anonymous users will never be listed)
 
-### 0.2.0 (2012-01-04)
+### 0.2.0
+
+Released on January 4, 2012.
 
 - Only tested with SMW 1.7 and MW 1.18.
 - Changed name for `_EUSER` and `_CUSER` props in both English and Swedish, article ###> page for clarity.
 - Using $smwgPageSpecialProperties2 to chose which properties to set, the same way as $smwgPageSpecialProperties
 is used for built in special properties
-- Ignoring `_VIEWS` if statistics are disables in LocalSettings
-- Added `_SUBP`, `_NREV` and `_NTREV`
+- Ignoring `_VIEWS` if statistics are disables in "LocalSettings.php"
+- Added `_SUBP`, `_NREV` and `_NTREV` special properties
 
 ### 0.1 (2011-11-25)
+
+Released on November 25, 2011.
 
 * Initial release

--- a/SemanticExtraSpecialProperties.php
+++ b/SemanticExtraSpecialProperties.php
@@ -18,7 +18,7 @@ if ( version_compare( $GLOBALS['wgVersion'], '1.25', '<' ) ) {
 }
 
 if ( !defined( 'SMW_VERSION' ) ) {
-	die( '<b>Error:</b> This version of Semantic Extra Special Properties requires <a href="http://semantic-mediawiki.org/wiki/Semantic_MediaWiki">Semantic MediaWiki</a> installed.<br />' );
+	die( '<b>Error:</b> This version of Semantic Extra Special Properties requires <a href="http://www.semantic-mediawiki.org/wiki/Semantic_MediaWiki">Semantic MediaWiki</a> installed.<br />' );
 }
 
 if ( defined( 'SESP_VERSION' ) ) {
@@ -65,7 +65,7 @@ class SemanticExtraSpecialProperties {
 	 */
 	public static function initExtension() {
 
-		define( 'SESP_VERSION', '1.4.0-alpha' );
+		define( 'SESP_VERSION', '1.4.0' );
 
 		// Register extension info
 		$GLOBALS['wgExtensionCredits']['semantic'][] = array(

--- a/composer.json
+++ b/composer.json
@@ -15,15 +15,22 @@
 	"authors": [
 		{
 			"name": "Leo Wallentin",
-			"homepage": "https://github.com/rotsee"
+			"homepage": "https://github.com/rotsee",
+			"role": "Creator"
 		},
 		{
-			"name": "mwjames",
-			"homepage": "https://semantic-mediawiki.org/wiki/User:MWJames"
+			"name": "James Hong Kong",
+			"homepage": "https://semantic-mediawiki.org/wiki/User:MWJames",
+			"role": "Developer"
 		}
 	],
 	"support": {
-		"irc": "irc://irc.freenode.net/semantic-mediawiki"
+		"email": "semediawiki-user@lists.sourceforge.net",
+		"issues": "https://github.com/SemanticMediaWiki/SemanticExtraSpecialProperties/issues",
+		"irc": "irc://irc.freenode.net/semantic-mediawiki",
+		"forum": "https://www.semantic-mediawiki.org/wiki/semantic-mediawiki.org_talk:Community_portal",
+		"wiki": "https://www.semantic-mediawiki.org/wiki/",
+		"source": "https://github.com/SemanticMediaWiki/SemanticExtraSpecialProperties"
 	},
 	"require": {
 		"php": ">=5.3.0",

--- a/docs/01-configuration.md
+++ b/docs/01-configuration.md
@@ -24,9 +24,6 @@ Property labels are displayed in accordance with the maintained [content languag
 - `_CUSER` adds a property with the user that created this page
 - `_REVID` adds a property with current revision ID
 - `_PAGEID` adds a property with the page ID
-- `_VIEWS` adds a property with number of page views. Note that depending on local settings this value might not be
-very up to date. If [`$wgDisableCounters`][$wgDisableCounters] is set to
-"true" this property will never be set.
 - `_NREV` adds a property showing an estimated number of total revisions of a page
 - `_NTREV` same as `_NREV` but for the talk page, i.e. showing how much discussion is going on around this page
 - `_SUBP` adds a property with all subpages
@@ -37,8 +34,8 @@ very up to date. If [`$wgDisableCounters`][$wgDisableCounters] is set to
 
 #### Properties with further dependencies
 
-- `_SHORTURL` add short URL if the [ShortUrl][ShortUrl]
-is installed, and there is a shortened URL for the current page
+- `_SHORTURL` adds short URL if the [ShortUrl][ShortUrl] extension is installed, and there is a shortened URL for the current page
+- `_VIEWS` adds a property with number of page views if the [HitCounters][HitCounters] extension is installed. This is required starting with MediaWiki 1.25 and later. In earlier versions of MediaWiki this special property used to work out of the box if enabled. Note that depending on local settings this value might not be very up to date. If [`$wgDisableCounters`][$wgDisableCounters] is set to "true" this property will never be set.
 
 #### Depreciated properties
 
@@ -83,6 +80,7 @@ can pose a [privacy issue][privacy].
 [MIME type]: https://semantic-mediawiki.org/wiki/Help:Special_property_MIME_type
 [Media type]: https://semantic-mediawiki.org/wiki/Help:Special_property_Media_type
 [ShortUrl]: https://www.mediawiki.org/wiki/Extension:ShortUrl
+[HitCounters]: https://www.mediawiki.org/wiki/Extension:HitCounters
 [data-refresh]: https://semantic-mediawiki.org/wiki/Help:Data_refresh#Examples
 [mw-update]: https://www.mediawiki.org/wiki/Manual:Update.php
 [mw-localsettings]: https://www.mediawiki.org/wiki/Localsettings


### PR DESCRIPTION
Make 1.4.0 release. Refs https://github.com/SemanticMediaWiki/SemanticExtraSpecialProperties/issues/71

* Extend information about the 1.4.0 release
* Reformatted information on older releases
* Provided some tweaks to older release notes