### PR TITLE
Allows to add page length to pages

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,12 @@
 This file contains the RELEASE-NOTES of the SemanticExtraSpecialProperties (a.k.a. SESP) extension.
 
+### 1,5,0
+
+This is not a release yet.
+
+* #74 Added `_PAGELGTH` for page length (size in bytes) collection on pages
+* Localization updates from https://translatewiki.net
+
 ### 1.4.0
 
 Released on January 22, 2017.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,6 @@
 This file contains the RELEASE-NOTES of the SemanticExtraSpecialProperties (a.k.a. SESP) extension.
 
-### 1,5,0
+### 1.5.0
 
 This is not a release yet.
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -11,6 +11,7 @@
 	"sesp-property-first-author": "Page creator",
 	"sesp-property-revision-id": "Revision ID",
 	"sesp-property-page-id": "Page ID",
+	"sesp-property-page-len": "Page length",
 	"sesp-property-view-count": "Number of page views",
 	"sesp-property-subpages": "Subpage",
 	"sesp-property-revisions": "Number of revisions",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -10,6 +10,7 @@
 	"sesp-property-first-author": "The name of the special property that stores the user that created the page.\n{{Doc-smw-sp}}",
 	"sesp-property-revision-id": "The name of the special property that stores the current revision ID.\n{{Doc-smw-sp}}\n{{Identical|Revision ID}}",
 	"sesp-property-page-id": "The name of the special property that stores the page ID.\n{{Doc-smw-sp}}\n{{Identical|Page ID}}",
+	"sesp-property-page-len": "The name of the special property that stores the page length (size in bytes)\n{{Doc-smw-sp}}",
 	"sesp-property-view-count": "The name of the special property that stores the number of pages views.\n{{Doc-smw-sp}}",
 	"sesp-property-subpages": "The name of the special property that stores subpages.\n{{Doc-smw-sp}}\n{{Identical|Subpage}}",
 	"sesp-property-revisions": "The name of the special property that stores the number of revisions.\n{{Doc-smw-sp}}",

--- a/src/Annotator/ExtraPropertyAnnotator.php
+++ b/src/Annotator/ExtraPropertyAnnotator.php
@@ -269,14 +269,14 @@ class ExtraPropertyAnnotator {
 		}
 	}
 
-	private function makePageLengthItem() {
-		$pageLen = $this->getWikiPage()->getLen();
-		
+	private function makePageLengthDataItem() {
+		$pageLen = $this->getWikiPage()->getTitle()->getLength();
+
 		if ( is_integer( $pageLen ) && $pageLen > 0 ) {
 			return new DINumber( $pageLen );
 		}
 	}
-	
+
 	private function makeRevisionIdDataItem() {
 		$revID = $this->getWikiPage()->getLatest();
 

--- a/src/Annotator/ExtraPropertyAnnotator.php
+++ b/src/Annotator/ExtraPropertyAnnotator.php
@@ -165,6 +165,9 @@ class ExtraPropertyAnnotator {
 			case '_PAGEID' :
 				$dataItem = $this->makePageIdDataItem();
 				break;
+			case '_PAGELGTH' :
+				$dataItem = $this->makePageLengthDataItem();
+				break;
 			case '_REVID' :
 				$dataItem = $this->makeRevisionIdDataItem();
 				break;
@@ -266,6 +269,14 @@ class ExtraPropertyAnnotator {
 		}
 	}
 
+	private function makePageLengthItem() {
+		$pageID = $this->getWikiPage()->getLen();
+		
+		if ( is_integer( $pageLen ) && $pageLen > 0 ) {
+			return new DINumber( $pageLen );
+		}
+	}
+	
 	private function makeRevisionIdDataItem() {
 		$revID = $this->getWikiPage()->getLatest();
 

--- a/src/Annotator/ExtraPropertyAnnotator.php
+++ b/src/Annotator/ExtraPropertyAnnotator.php
@@ -270,7 +270,7 @@ class ExtraPropertyAnnotator {
 	}
 
 	private function makePageLengthItem() {
-		$pageID = $this->getWikiPage()->getLen();
+		$pageLen = $this->getWikiPage()->getLen();
 		
 		if ( is_integer( $pageLen ) && $pageLen > 0 ) {
 			return new DINumber( $pageLen );

--- a/src/Definition/definitions.json
+++ b/src/Definition/definitions.json
@@ -13,6 +13,13 @@
         "alias": "sesp-property-page-id",
         "label": "Page ID"
     },
+    "_PAGELGTH": {
+        "id": "___PAGELGTH",
+        "type": 1,
+        "show": false,
+        "alias": "sesp-property-page-len",
+        "label": "Page length"
+    },
     "_EUSER": {
         "id": "___EUSER",
         "type": 9,

--- a/tests/phpunit/Unit/Annotator/ExtraPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/Annotator/ExtraPropertyAnnotatorTest.php
@@ -371,4 +371,38 @@ class ExtraPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 		return $instance;
 	}
 
+	public function testPropertyAnnotation_PAGELGTH() {
+
+		$title = $this->getMockBuilder( 'Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->once() )
+			->method( 'getLength' )
+			->will( $this->returnValue( 42 ) );
+
+		$page = $this->getMockBuilder( 'WikiPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$page->expects( $this->once() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $title ) );
+
+		$this->appFactory->expects( $this->once() )
+			->method( 'newWikiPage' )
+			->will( $this->returnValue( $page ) );
+
+		$instance = $this->newExtraPropertyAnnotatorInstanceFor( '_PAGELGTH' );
+
+		$semanticData = $instance->getSemanticData();
+
+		$instance->addAnnotation();
+
+		$this->assertArrayHasKey(
+			PropertyRegistry::getInstance()->getPropertyId( '_PAGELGTH' ),
+			$semanticData->getProperties()
+		);
+	}
+
 }

--- a/tests/phpunit/Unit/PropertyRegistryTest.php
+++ b/tests/phpunit/Unit/PropertyRegistryTest.php
@@ -138,6 +138,7 @@ class PropertyRegistryTest extends \PHPUnit_Framework_TestCase {
 				'_EUSER',
 				'_REVID',
 				'_PAGEID',
+				'_PAGELGTH',
 				'_VIEWS',
 				'_NREV',
 				'_NTREV',


### PR DESCRIPTION
Added `_PAGELGTH` for page length (size in bytes) collection on pages

Refs: https://github.com/SemanticMediaWiki/SemanticExtraSpecialProperties/issues/74