### PR TITLE
Add LabelFetcher with cache layer

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -32,7 +32,12 @@ return array(
 	/**
 	 * Specifies the enabled properties
 	 */
-	'sespSpecialProperties' =>  array(),
+	'sespSpecialProperties' => array(),
+
+	/**
+	 * Specifies an internal cache modifier
+	 */
+	'sespLabelCacheVersion' => '2017.06',
 
 	/**
 	 * It causes bot edits via user accounts in usergroup "bot" to be ignored when

--- a/SemanticExtraSpecialProperties.php
+++ b/SemanticExtraSpecialProperties.php
@@ -120,7 +120,8 @@ class SemanticExtraSpecialProperties {
 			'wgShortUrlPrefix'        => $GLOBALS['wgShortUrlPrefix'],
 			'sespPropertyDefinitionFile' => $GLOBALS['sespPropertyDefinitionFile'],
 			'sespLocalPropertyDefinitions' => $GLOBALS['sespLocalPropertyDefinitions'],
-			'sespPropertyDefinitions' => array()
+			'sespLabelCacheVersion' => $GLOBALS['sespLabelCacheVersion'],
+			'sespPropertyDefinitions' => array(),
 		);
 
 		$hookRegistry = new HookRegistry(

--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
 		"process-timeout": 0
 	},
 	"scripts": {
-		"phpunit": "php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist"
+		"phpunit": "php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist",
+		"phpdbg": "phpdbg -qrr ../../tests/phpunit/phpunit.php -c phpunit.xml.dist"
 	}
 }

--- a/docs/00-configuration.md
+++ b/docs/00-configuration.md
@@ -1,9 +1,8 @@
 
-[Extension](01-extension.md) &rarr;
-
 # Configuration
 
 Properties that are planned to be included need to be specified in the [`LocalSettings.php`][mw-localsettings] file using the `$GLOBALS['sespSpecialProperties']` array. By default the array is empty, i.e. no special property is being annotated to a page.
+
 ```php
 $GLOBALS['sespSpecialProperties'] = array(
 	'_EUSER',
@@ -62,6 +61,9 @@ as the `_EUSER` property will list all authors for everyone.
 
 The Exchangeable image file format (and thereof its Exif tags) can contain metadata about a location which
 can pose a [privacy issue][privacy].
+
+&larr; [README](README.md) | [Extension](01-extension.md) &rarr;
+
 
 [smw]: https://www.semantic-mediawiki.org/wiki/Semantic_MediaWiki
 [subobject]: https://semantic-mediawiki.org/wiki/Subobject

--- a/docs/01-extension.md
+++ b/docs/01-extension.md
@@ -1,5 +1,8 @@
 
-&larr; [Configuration](00-configuration.md)
+# Extension
+
+* [Repository extensio](#repository-extension)
+* [Local extension](#local-extension)
 
 ## Repository extension
 
@@ -47,8 +50,8 @@ Expand the property definition in `definitions.json` with something like:
   placed in the corresponding folder, and contain the details required for the value annotation supported by
   the related property
 - Add a complementary test class (e.g. `MyExt1PropertyAnnotatorTest`) to test the newly added functionality
-- Register the service with the `ExtraPropertyAnnotator`
-- Extend the `ExtraPropertyAnnotator` test to cover the newly added service
+- Register the service with the `DispatchingPropertyAnnotator`
+- Extend the `DispatchingPropertyAnnotator` test to cover the newly added service
 
 ## Local extension
 
@@ -105,3 +108,5 @@ class FooCustom {
 	}
 }
 ```
+
+&larr; [Configuration](00-configuration.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+
+* [Configuration](00-configuration.md) explains essential configuration parameters
+* [Extension](01-extension.md) illustrates how to extend and add new special properties

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -7,6 +7,7 @@
 		]
 	},
 	"sesp-desc": "Adds some extra special properties to all pages",
+	"sesp-property-unknown-label": "Unknown label or alias",
 	"sesp-property-author": "Page author",
 	"sesp-property-first-author": "Page creator",
 	"sesp-property-revision-id": "Revision ID",

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -106,16 +106,15 @@ class HookRegistry {
 
 	private function registerCallbackHandlers( $configuration ) {
 
-		$appFactory = new AppFactory(
-			$configuration
-		);
+		$applicationFactory = \SMW\ApplicationFactory::getInstance();
 
-		$appFactory->setConnection(
-			wfGetDB( DB_SLAVE )
+		$appFactory = new AppFactory(
+			$configuration,
+			$applicationFactory->getCache()
 		);
 
 		$appFactory->setLogger(
-			\SMW\ApplicationFactory::getInstance()->getMediaWikiLogger( 'sesp' )
+			$applicationFactory->getMediaWikiLogger( 'sesp' )
 		);
 
 		$propertyRegistry = new PropertyRegistry(

--- a/src/LabelFetcher.php
+++ b/src/LabelFetcher.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace SESP;
+
+use Onoi\Cache\Cache;
+use Onoi\Cache\NullCache;
+use SMW\Message;
+
+/**
+ * @ingroup SESP
+ *
+ * @license GNU GPL v2+
+ * @since 2.0
+ *
+ * @author mwjames
+ */
+class LabelFetcher {
+
+	/**
+	 * Namespace of the cache instance
+	 */
+	const LABEL_CACHE_NAMESPACE = 'sesp:labels';
+
+	/**
+	 * @var Cache
+	 */
+	private $cache;
+
+	/**
+	 * @var string
+	 */
+	private $languageCode = 'en';
+
+	/**
+	 * @var string
+	 */
+	private $labelCacheVersion = 0;
+
+	/**
+	 * @since 2.0
+	 *
+	 * @param Cache|null $cache
+	 * @param string $languageCode
+	 */
+	public function __construct( Cache $cache = null, $languageCode = 'en' ) {
+		$this->cache = $cache;
+		$this->languageCode = $languageCode;
+
+		if ( $this->cache === null ) {
+			$this->cache = new NullCache();
+		}
+	}
+
+	/**
+	 * @since 2.0
+	 *
+	 * @param integer|string $labelCacheVersion
+	 */
+	public function setLabelCacheVersion( $labelCacheVersion ) {
+		$this->labelCacheVersion = $labelCacheVersion;
+	}
+
+	/**
+	 * @since 2.0
+	 *
+	 * @param string $key
+	 *
+	 * @return string
+	 */
+	public function getLabel( $key ) {
+		return Message::get( $key, null, Message::USER_LANGUAGE );
+	}
+
+	/**
+	 * @since 2.0
+	 *
+	 * @param PropertyDefinitions $propertyDefinitions
+	 *
+	 * @return array
+	 */
+	public function getLabelsFrom( PropertyDefinitions $propertyDefinitions ) {
+
+		$hash = smwfCacheKey(
+			self::LABEL_CACHE_NAMESPACE,
+			array(
+				$propertyDefinitions,
+				$this->languageCode,
+				$this->labelCacheVersion
+			)
+		);
+
+		if ( $this->labelCacheVersion !== false && ( $labels = $this->cache->fetch( $hash ) ) !== false ) {
+			return $labels;
+		}
+
+		$labels = array();
+		$exifDefinitions = array();
+
+		foreach ( $propertyDefinitions as $key => $definition ) {
+			$this->matchLabel( $labels, $definition );
+		}
+
+		foreach ( $propertyDefinitions->safeGet( '_EXIF', array() ) as $key => $definition ) {
+			$this->matchLabel( $labels, $definition );
+		}
+
+		if ( $labels !== array() ) {
+			$this->cache->save( $hash, $labels, 3600 * 24 );
+		}
+
+		return $labels;
+	}
+
+	private function matchLabel( &$labels, $definition ) {
+
+		if ( !isset( $definition['id'] ) ) {
+			return;
+		}
+
+		$alias = 'sesp-property-unknown-label';
+
+		if ( isset( $definition['alias'] ) ) {
+			$alias = $definition['alias'];
+		}
+
+		$labels[$definition['id']] = Message::get( $alias, null, $this->languageCode );
+	}
+
+}

--- a/src/PropertyDefinitions.php
+++ b/src/PropertyDefinitions.php
@@ -2,6 +2,9 @@
 
 namespace SESP;
 
+use Onoi\Cache\Cache;
+use Onoi\Cache\NullCache;
+use SMW\Message;
 use IteratorAggregate;
 use ArrayIterator;
 use InvalidArgumentException;
@@ -17,9 +20,19 @@ use InvalidArgumentException;
 class PropertyDefinitions implements IteratorAggregate {
 
 	/**
+	 * @var LabelFetcher
+	 */
+	private $labelFetcher;
+
+	/**
 	 * @var string
 	 */
 	private $propertyDefinitionFile;
+
+	/**
+	 * @var string
+	 */
+	private $labelCacheVersion = 0;
 
 	/**
 	 * @var array|null
@@ -34,9 +47,11 @@ class PropertyDefinitions implements IteratorAggregate {
 	/**
 	 * @since 2.0
 	 *
+	 * @param LabelFetcher $labelFetcher
 	 * @param string $propertyDefinitionFile
 	 */
-	public function __construct( $propertyDefinitionFile = '' ) {
+	public function __construct( LabelFetcher $labelFetcher, $propertyDefinitionFile = '' ) {
+		$this->labelFetcher = $labelFetcher;
 		$this->propertyDefinitionFile = $propertyDefinitionFile;
 
 		if ( $this->propertyDefinitionFile === '' ) {
@@ -139,6 +154,31 @@ class PropertyDefinitions implements IteratorAggregate {
 	 */
 	public function safeGet( $key, $default = false ) {
 		return $this->has( $key ) ? $this->propertyDefinitions[$key] : $default;
+	}
+
+	/**
+	 * @since 2.0
+	 *
+	 * @return array
+	 */
+	public function getLabels() {
+
+		if ( $this->propertyDefinitions === null ) {
+			$this->initPropertyDefinitions();
+		}
+
+		return $this->labelFetcher->getLabelsFrom( $this );
+	}
+
+	/**
+	 * @since 2.0
+	 *
+	 * @param string $key
+	 *
+	 * @return string
+	 */
+	public function getLabel( $key ) {
+		return $this->labelFetcher->getLabel( $key );
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 
-if ( PHP_SAPI !== 'cli' ) {
+if ( PHP_SAPI !== 'cli' && PHP_SAPI !== 'phpdbg' ) {
 	die( 'Not an entry point' );
 }
 

--- a/tests/phpunit/Unit/AppFactoryTest.php
+++ b/tests/phpunit/Unit/AppFactoryTest.php
@@ -106,8 +106,15 @@ class AppFactoryTest extends \PHPUnit_Framework_TestCase {
 			$options
 		);
 
+		$propertyDefinitions = $instance->getPropertyDefinitions();
+
 		$this->assertInstanceOf(
 			'\SESP\PropertyDefinitions',
+			$propertyDefinitions
+		);
+
+		$this->assertSame(
+			$propertyDefinitions,
 			$instance->getPropertyDefinitions()
 		);
 	}
@@ -117,7 +124,18 @@ class AppFactoryTest extends \PHPUnit_Framework_TestCase {
 		$instance = new AppFactory();
 
 		$this->assertInstanceOf(
-			'\Psr\Log\LoggerInterface',
+			'\Psr\Log\NullLogger',
+			$instance->getLogger()
+		);
+
+		$logger = $this->getMockBuilder( '\Psr\Log\LoggerInterface' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance->setLogger( $logger );
+
+		$this->assertSame(
+			$logger,
 			$instance->getLogger()
 		);
 	}

--- a/tests/phpunit/Unit/ExtraPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/ExtraPropertyAnnotatorTest.php
@@ -70,7 +70,13 @@ class ExtraPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 			'callback' => $callback
 		);
 
-		$propertyDefinitions = new PropertyDefinitions();
+		$labelFetcher = $this->getMockBuilder( '\SESP\LabelFetcher' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$propertyDefinitions = new PropertyDefinitions(
+			$labelFetcher
+		);
 
 		$propertyDefinitions->setLocalPropertyDefinitions(
 			$localPropertyDefinitions
@@ -115,7 +121,13 @@ class ExtraPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 			'id'    => 'FAKE2'
 		);
 
-		$propertyDefinitions = new PropertyDefinitions();
+		$labelFetcher = $this->getMockBuilder( '\SESP\LabelFetcher' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$propertyDefinitions = new PropertyDefinitions(
+			$labelFetcher
+		);
 
 		$propertyDefinitions->setPropertyDefinitions(
 			$defs

--- a/tests/phpunit/Unit/LabelFetcherTest.php
+++ b/tests/phpunit/Unit/LabelFetcherTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace SESP\Tests;
+
+use SESP\LabelFetcher;
+
+/**
+ * @covers \SESP\LabelFetcher
+ * @group SESP
+ *
+ * @license GNU GPL v2+
+ * @since 2.0
+ *
+ * @author mwjames
+ */
+class LabelFetcherTest extends \PHPUnit_Framework_TestCase {
+
+	private $cache;
+
+	protected function setup() {
+		parent::setUp();
+
+		$this->cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			LabelFetcher::class,
+			new LabelFetcher( $this->cache )
+		);
+	}
+
+	public function testGetLabel() {
+
+		$instance = new LabelFetcher(
+			$this->cache
+		);
+
+		$this->assertInternalType(
+			'string',
+			$instance->getLabel( 'Foo' )
+		);
+	}
+
+	public function testGetLabelsUnCached() {
+
+		$defs = [
+			'FOO' => [ 'id' => 'Foo', 'alias' => 'Foo' ],
+			'_EXIF' => [
+				'BAR' => [ 'id' => 'Bar', 'alias' => 'Bar' ]
+			]
+		];
+
+		$propertyDefinitions = $this->getMockBuilder( '\SESP\PropertyDefinitions' )
+			->disableOriginalConstructor()
+			->setMethods( null )
+			->getMock();
+
+		$propertyDefinitions->setPropertyDefinitions(
+			$defs
+		);
+
+		$this->cache->expects( $this->once() )
+			->method( 'fetch' )
+			->will( $this->returnValue( false ) );
+
+		$this->cache->expects( $this->once() )
+			->method( 'save' );
+
+		$instance = new LabelFetcher(
+			$this->cache
+		);
+
+		$this->assertInternalType(
+			'array',
+			$instance->getLabelsFrom( $propertyDefinitions )
+		);
+	}
+
+	public function testGetLabelsCached() {
+
+		$labels = [
+			'FOO' => 'Bar'
+		];
+
+		$propertyDefinitions = $this->getMockBuilder( '\SESP\PropertyDefinitions' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getLabels' ) )
+			->getMock();
+
+		$this->cache->expects( $this->once() )
+			->method( 'fetch' )
+			->will( $this->returnValue( $labels ) );
+
+		$this->cache->expects( $this->never() )
+			->method( 'save' );
+
+		$instance = new LabelFetcher(
+			$this->cache
+		);
+
+		$instance->getLabelsFrom( $propertyDefinitions );
+	}
+
+	public function testGetLabelsCachedVersioned() {
+
+		$labels = [
+			'FOO' => 'Bar'
+		];
+
+		$propertyDefinitions = $this->getMockBuilder( '\SESP\PropertyDefinitions' )
+			->disableOriginalConstructor()
+			->setMethods( null )
+			->getMock();
+
+		$this->cache->expects( $this->once() )
+			->method( 'fetch' )
+			->with( $this->stringContains( 'sesp:labels:e1484da79bc6323bcb087894cf9cab03' ) )
+			->will( $this->returnValue( $labels ) );
+
+		$instance = new LabelFetcher(
+			$this->cache
+		);
+
+		$instance->setLabelCacheVersion(
+			2
+		);
+
+		$instance->getLabelsFrom( $propertyDefinitions );
+	}
+
+}

--- a/tests/phpunit/Unit/PropertyAnnotators/ExifPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ExifPropertyAnnotatorTest.php
@@ -108,7 +108,13 @@ class ExifPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testAddAnnotation( $meta, $defs, $expected ) {
 
-		$propertyDefinitions = new PropertyDefinitions();
+		$labelFetcher = $this->getMockBuilder( '\SESP\LabelFetcher' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$propertyDefinitions = new PropertyDefinitions(
+			$labelFetcher
+		);
 
 		$propertyDefinitions->setPropertyDefinitions(
 			$defs

--- a/tests/phpunit/Unit/PropertyDefinitionsTest.php
+++ b/tests/phpunit/Unit/PropertyDefinitionsTest.php
@@ -15,17 +15,29 @@ use SESP\PropertyDefinitions;
  */
 class PropertyDefinitionsTest extends \PHPUnit_Framework_TestCase {
 
+	private $labelFetcher;
+
+	protected function setup() {
+		parent::setUp();
+
+		$this->labelFetcher = $this->getMockBuilder( '\SESP\LabelFetcher' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(
 			PropertyDefinitions::class,
-			new PropertyDefinitions()
+			new PropertyDefinitions( $this->labelFetcher )
 		);
 	}
 
 	public function testEmptyFile() {
 
-		$instance = new PropertyDefinitions();
+		$instance = new PropertyDefinitions(
+			$this->labelFetcher
+		);
 
 		$this->assertInstanceOf(
 			'\ArrayIterator',
@@ -42,7 +54,9 @@ class PropertyDefinitionsTest extends \PHPUnit_Framework_TestCase {
 		$key = 'SOFTWARE';
 		$expected = [ 'id' => 'Foo', 'type' => '_txt' ];
 
-		$instance = new PropertyDefinitions();
+		$instance = new PropertyDefinitions(
+			$this->labelFetcher
+		);
 
 		$instance->setPropertyDefinitions(
 			$defs
@@ -58,6 +72,34 @@ class PropertyDefinitionsTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testSafeGet() {
+
+		$defs = [
+			'SOFTWARE' => [ 'id' => 'Foo', 'type' => '_txt' ]
+		];
+
+		$key = 'SOFTWARE';
+		$expected = [ 'id' => 'Foo', 'type' => '_txt' ];
+
+		$instance = new PropertyDefinitions(
+			$this->labelFetcher
+		);
+
+		$instance->setPropertyDefinitions(
+			$defs
+		);
+
+		$this->assertEquals(
+			[],
+			$instance->safeGet( 'Foo', [] )
+		);
+
+		$this->assertEquals(
+			$expected,
+			$instance->safeGet( $key )
+		);
+	}
+
 	public function testDeepHasGet() {
 
 		$defs = [
@@ -67,7 +109,9 @@ class PropertyDefinitionsTest extends \PHPUnit_Framework_TestCase {
 		$key = 'SOFTWARE';
 		$expected = 'Foo';
 
-		$instance = new PropertyDefinitions();
+		$instance = new PropertyDefinitions(
+			$this->labelFetcher
+		);
 
 		$instance->setPropertyDefinitions(
 			$defs
@@ -81,6 +125,52 @@ class PropertyDefinitionsTest extends \PHPUnit_Framework_TestCase {
 			$expected,
 			$instance->deepGet( $key, 'id' )
 		);
+	}
+
+	public function testLocalDef() {
+
+		$defs = [
+			'SOFTWARE' => [ 'id' => 'Foo', 'type' => '_txt' ]
+		];
+
+		$key = 'SOFTWARE';
+		$expected = 'Foo';
+
+		$instance = new PropertyDefinitions(
+			$this->labelFetcher
+		);
+
+		$instance->setLocalPropertyDefinitions(
+			$defs
+		);
+
+		$this->assertTrue(
+			$instance->isLocalDef( $key )
+		);
+	}
+
+	public function testGetLabels() {
+
+		$this->labelFetcher->expects( $this->once() )
+			->method( 'getLabelsFrom' );
+
+		$instance = new PropertyDefinitions(
+			$this->labelFetcher
+		);
+
+		$instance->getLabels();
+	}
+
+	public function testGetLabel() {
+
+		$this->labelFetcher->expects( $this->once() )
+			->method( 'getLabel' );
+
+		$instance = new PropertyDefinitions(
+			$this->labelFetcher
+		);
+
+		$instance->getLabel( 'Foo' );
 	}
 
 }

--- a/tests/phpunit/Unit/PropertyRegistryTest.php
+++ b/tests/phpunit/Unit/PropertyRegistryTest.php
@@ -39,7 +39,7 @@ class PropertyRegistryTest extends \PHPUnit_Framework_TestCase {
 
 		$propertyDefinitions = $this->getMockBuilder( '\SESP\PropertyDefinitions' )
 			->disableOriginalConstructor()
-			->setMethods( null )
+			->setMethods( array( 'getLabels' ) )
 			->getMock();
 
 		$propertyDefinitions->setPropertyDefinitions(
@@ -69,7 +69,7 @@ class PropertyRegistryTest extends \PHPUnit_Framework_TestCase {
 
 		$propertyDefinitions = $this->getMockBuilder( '\SESP\PropertyDefinitions' )
 			->disableOriginalConstructor()
-			->setMethods( null )
+			->setMethods( array( 'getLabels', 'getLabel' ) )
 			->getMock();
 
 		$propertyDefinitions->setPropertyDefinitions(
@@ -114,7 +114,7 @@ class PropertyRegistryTest extends \PHPUnit_Framework_TestCase {
 
 		$propertyDefinitions = $this->getMockBuilder( '\SESP\PropertyDefinitions' )
 			->disableOriginalConstructor()
-			->setMethods( null )
+			->setMethods( array( 'getLabels', 'getLabel' ) )
 			->getMock();
 
 		$propertyDefinitions->setPropertyDefinitions(
@@ -180,7 +180,9 @@ class PropertyRegistryTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$propertyDefinitions->setPropertyDefinitions(
-			array()
+			array(
+				'Foo' => [ 'id' => '___FOO' ]
+			)
 		);
 
 		$this->appFactory->expects( $this->at( 0 ) )
@@ -195,7 +197,7 @@ class PropertyRegistryTest extends \PHPUnit_Framework_TestCase {
 		$this->appFactory->expects( $this->at( 2 ) )
 			->method( 'getOption' )
 			->with( $this->stringContains( 'sespSpecialProperties' ) )
-			->will( $this->returnValue( array() ) );
+			->will( $this->returnValue( array( 'Foo' ) ) );
 
 		$instance = new PropertyRegistry(
 			$this->appFactory
@@ -205,6 +207,16 @@ class PropertyRegistryTest extends \PHPUnit_Framework_TestCase {
 		$fixedPropertyTablePrefix = array();
 
 		$instance->registerAsFixedProperties( $customFixedProperties, $fixedPropertyTablePrefix );
+
+		$this->assertArrayHasKey(
+			'___FOO',
+			$customFixedProperties
+		);
+
+		$this->assertEquals(
+			['___FOO' => 'smw_ftp_sesp' ],
+			$fixedPropertyTablePrefix
+		);
 	}
 
 }


### PR DESCRIPTION
Looking at some simple profiling, it should be clear that using labels (means MediaWiki's `Message` class) without a cache creates some unfortunate performance deficiencies. 

- Without cache [smw] SMW\PropertyRegistry ... after hook (procTime in sec: 0.22195)
- With cache [smw] SMW\PropertyRegistry ... after hook (procTime in sec: 0.03243)

Setting `$GLOBALS['sespLabelCacheVersion']` was as added as internal modifier to allow resetting the cache with an arbitrary version or if set false will cease to use the cache at all.

refs #75
