### PR TITLE
Add ability to track information from ApprovedRevisions

### DIFF
--- a/definitions.json
+++ b/definitions.json
@@ -14,14 +14,14 @@
 		"label": "Page ID",
 		"desc": "sesp-property-page-id-desc"
 	},
-    "_PAGELGTH": {
-        "id": "___PAGELGTH",
-        "type": "_num",
-        "show": false,
-        "alias": "sesp-property-page-len",
-        "label": "Page length",
-        "desc": "sesp-property-page-len-desc"
-    },
+	"_PAGELGTH": {
+		"id": "___PAGELGTH",
+		"type": "_num",
+		"show": false,
+		"alias": "sesp-property-page-len",
+		"label": "Page length",
+		"desc": "sesp-property-page-len-desc"
+	},
 	"_EUSER": {
 		"id": "___EUSER",
 		"type": "_wpg",
@@ -42,6 +42,14 @@
 		"show": false,
 		"alias": "sesp-property-view-count",
 		"label": "Number of page views"
+	},
+	"_APPROVED": {
+		"id": "___APPROVED",
+		"type": "_num",
+		"show": false,
+		"alias": "sesp-property-approved-rev",
+		"label": "Approved revision",
+		"desc": "sesp-property-approved-rev-desc"
 	},
 	"_SUBP": {
 		"id": "___SUBP",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -22,6 +22,8 @@
 	"sesp-property-mimetype": "MIME type",
 	"sesp-property-mediatype": "Media type",
 	"sesp-property-shorturl": "Short URL",
+	"sesp-property-approved-rev": "Approved revision",
+	"sesp-property-approved-rev-desc": "\"$1\" identifies the revision ID of a page that has been approved (via the [https://www.semantic-mediawiki.org/wiki/Extension:Semantic_Extra_Special_Properties SESP] extension).",
 	"sesp-property-user-registration-date": "User registration date",
 	"sesp-property-user-edit-count": "User edit count",
 	"sesp-property-exif-data": "Exif data",

--- a/src/PropertyAnnotators/ApprovedRevPropertyAnnotator.php
+++ b/src/PropertyAnnotators/ApprovedRevPropertyAnnotator.php
@@ -6,7 +6,6 @@ use SMW\DIProperty;
 use SMW\SemanticData;
 use SMWDataItem as DataItem;
 use SMWDINumber as DINumber;
-use SMWDIBoolean as DIBool;
 use SESP\PropertyAnnotator;
 use SESP\AppFactory;
 use ApprovedRevs;
@@ -30,10 +29,24 @@ class ApprovedRevPropertyAnnotator implements PropertyAnnotator {
 	private $appFactory;
 
 	/**
+	 * @var Integer|null
+	 */
+	private $approvedRev;
+
+	/**
 	 * @param AppFactory $appFactory
 	 */
 	public function __construct( AppFactory $appFactory ) {
 		$this->appFactory = $appFactory;
+	}
+
+	/**
+	 * @since 2.0
+	 *
+	 * @param Integer $approvedRev
+	 */
+	public function setApprovedRev( $approvedRev ) {
+		$this->approvedRev = $approvedRev;
 	}
 
 	/**
@@ -46,16 +59,19 @@ class ApprovedRevPropertyAnnotator implements PropertyAnnotator {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function addAnnotation( DIProperty $property, SemanticData $semanticData ) {
-		if ( !class_exists( 'ApprovedRevs' ) ) {
-			return null;
+	public function addAnnotation(
+		DIProperty $property, SemanticData $semanticData
+	) {
+		if ( $this->approvedRev === null && class_exists( 'ApprovedRevs' ) ) {
+			$this->approvedRev = ApprovedRevs::getApprovedRevID(
+				$semanticData->getSubject()->getTitle()
+			);
 		}
 
-		$title = $semanticData->getSubject()->getTitle();
-		$rev = ApprovedRevs::getApprovedRevID( $title );
-
-		if ( is_numeric( $rev ) ) {
-			$semanticData->addPropertyObjectValue( $property, new DINumber( $rev ) );
+		if ( is_numeric( $this->approvedRev ) ) {
+			$semanticData->addPropertyObjectValue(
+				$property, new DINumber( $this->approvedRev )
+			);
 		} else {
 			$semanticData->removeProperty( $property );
 		}

--- a/src/PropertyAnnotators/ApprovedRevPropertyAnnotator.php
+++ b/src/PropertyAnnotators/ApprovedRevPropertyAnnotator.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace SESP\PropertyAnnotators;
+
+use SMW\DIProperty;
+use SMW\SemanticData;
+use SMWDataItem as DataItem;
+use SMWDINumber as DINumber;
+use SMWDIBoolean as DIBool;
+use SESP\PropertyAnnotator;
+use SESP\AppFactory;
+use ApprovedRevs;
+
+/**
+ * @private
+ * @ingroup SESP
+ *
+ * @license GNU GPL v2+
+ */
+class ApprovedRevPropertyAnnotator implements PropertyAnnotator {
+
+	/**
+	 * Predefined property ID
+	 */
+	const PROP_ID = '___APPROVED';
+
+	/**
+	 * @var AppFactory
+	 */
+	private $appFactory;
+
+	/**
+	 * @param AppFactory $appFactory
+	 */
+	public function __construct( AppFactory $appFactory ) {
+		$this->appFactory = $appFactory;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function isAnnotatorFor( DIProperty $property ) {
+		return $property->getKey() === self::PROP_ID;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function addAnnotation( DIProperty $property, SemanticData $semanticData ) {
+		if ( !class_exists( 'ApprovedRevs' ) ) {
+			return null;
+		}
+
+		$title = $semanticData->getSubject()->getTitle();
+		$rev = ApprovedRevs::getApprovedRevID( $title );
+
+		if ( is_numeric( $rev ) ) {
+			$semanticData->addPropertyObjectValue( $property, new DINumber( $rev ) );
+		} else {
+			$semanticData->removeProperty( $property );
+		}
+	}
+}

--- a/src/PropertyAnnotators/DispatchingPropertyAnnotator.php
+++ b/src/PropertyAnnotators/DispatchingPropertyAnnotator.php
@@ -111,6 +111,10 @@ class DispatchingPropertyAnnotator implements PropertyAnnotator {
 				return new PageViewsPropertyAnnotator( $appFactory );
 			},
 
+			ApprovedRevPropertyAnnotator::PROP_ID => function( $appFactory ) {
+				return new ApprovedRevPropertyAnnotator( $appFactory );
+			},
+
 			UserRegistrationDatePropertyAnnotator::PROP_ID => function( $appFactory ) {
 				return new UserRegistrationDatePropertyAnnotator( $appFactory );
 			},

--- a/tests/phpunit/Unit/PropertyAnnotators/ApprovedRevPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ApprovedRevPropertyAnnotatorTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace SESP\Tests\PropertyAnnotators;
+
+use SESP\PropertyAnnotators\ApprovedRevPropertyAnnotator;
+use SMW\DIProperty;
+use SMW\DIWikiPage;
+
+/**
+ * @covers \SESP\PropertyAnnotators\ApprovedRevPropertyAnnotator
+ * @group semantic-extra-special-properties
+ *
+ * @license GNU GPL v2+
+ * @since 2.0
+ *
+ * @author mwjames
+ */
+class ApprovedRevPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
+
+	private $property;
+	private $appFactory;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->appFactory = $this->getMockBuilder( '\SESP\AppFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->property = new DIProperty( '___APPROVED' );
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			ApprovedRevPropertyAnnotator::class,
+			new ApprovedRevPropertyAnnotator( $this->appFactory )
+		);
+	}
+
+	public function testIsAnnotatorFor() {
+
+		$instance = new ApprovedRevPropertyAnnotator(
+			$this->appFactory
+		);
+
+		$this->assertTrue(
+			$instance->isAnnotatorFor( $this->property )
+		);
+	}
+
+	public function testAddAnnotation() {
+
+		$subject = DIWikiPage::newFromText( __METHOD__ );
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->once() )
+			->method( 'getSubject' )
+			->will( $this->returnValue( $subject ) );
+
+		$instance = new ApprovedRevPropertyAnnotator(
+			$this->appFactory
+		);
+
+		$instance->addAnnotation( $this->property, $semanticData );
+	}
+}

--- a/tests/phpunit/Unit/PropertyAnnotators/ApprovedRevPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ApprovedRevPropertyAnnotatorTest.php
@@ -5,6 +5,7 @@ namespace SESP\Tests\PropertyAnnotators;
 use SESP\PropertyAnnotators\ApprovedRevPropertyAnnotator;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
+use SMWDINumber as DINumber;
 
 /**
  * @covers \SESP\PropertyAnnotators\ApprovedRevPropertyAnnotator
@@ -50,20 +51,39 @@ class ApprovedRevPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testAddAnnotation() {
-
-		$subject = DIWikiPage::newFromText( __METHOD__ );
-
 		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$semanticData->expects( $this->once() )
-			->method( 'getSubject' )
-			->will( $this->returnValue( $subject ) );
+			->method( 'addPropertyObjectValue' )
+			->with(
+				$this->equalTo( $this->property ),
+				$this->equalTo( new DINumber( 42 ) ) );
 
 		$instance = new ApprovedRevPropertyAnnotator(
 			$this->appFactory
 		);
+
+		$instance->setApprovedRev( 42 );
+
+		$instance->addAnnotation( $this->property, $semanticData );
+	}
+
+	public function testRemoval() {
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->once() )
+			->method( 'removeProperty' )
+			->with( $this->equalTo( $this->property ) );
+
+		$instance = new ApprovedRevPropertyAnnotator(
+			$this->appFactory
+		);
+
+		$instance->setApprovedRev( false );
 
 		$instance->addAnnotation( $this->property, $semanticData );
 	}


### PR DESCRIPTION
I'm not sure this is correct because there is no way to query if a page is covered by AR but has no  approved revision.  I could set the property to 0 in that case, which would expose the info, but is that the right thing to do?

Fixes #94 
