### PR TITLE
Rename settings, refs 92

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -17,33 +17,33 @@ return [
 	/**
 	 * To setup properties as fixed properties in order to improve data access
 	 */
-	'sespUseAsFixedTables' => false,
+	'sespgUseFixedTables' => false,
 
 	/**
 	 * Location of the property definitions
 	 */
-	'sespPropertyDefinitionFile' => __DIR__ . '/data/definitions.json',
+	'sespgDefinitionsFile' => __DIR__ . '/data/definitions.json',
 
 	/**
 	 * Specifies local definitions
 	 */
-	'sespLocalPropertyDefinitions' => [],
+	'sespgLocalDefinitions' => [],
 
 	/**
 	 * Specifies the enabled properties
 	 */
-	'sespSpecialProperties' => [],
+	'sespgEnabledPropertyList' => [],
 
 	/**
 	 * Specifies an internal cache modifier
 	 */
-	'sespLabelCacheVersion' => '2018.03',
+	'sespgLabelCacheVersion' => '2018.03',
 
 	/**
 	 * It causes bot edits via user accounts in usergroup "bot" to be ignored when
 	 * storing data for the special properties.
 	 */
-	'wgSESPExcludeBots' => false,
+	'sespgExcludeBotEdits' => false,
 
 	/**
 	 * Used in connection with ShortUrlUtils

--- a/SemanticExtraSpecialProperties.php
+++ b/SemanticExtraSpecialProperties.php
@@ -73,16 +73,56 @@ class SemanticExtraSpecialProperties {
 			}
 		}
 
+		// Cover legacy settings
+		$deprecationNotices = [];
+
+		if ( isset( $GLOBALS['sespUseAsFixedTables'] ) ) {
+			$GLOBALS['sespgUseFixedTables'] = $GLOBALS['sespUseAsFixedTables'];
+			$deprecationNotices['replacement']['sespUseAsFixedTables'] = 'sespgUseFixedTables';
+		}
+
+		if ( isset( $GLOBALS['sespPropertyDefinitionFile'] ) ) {
+			$GLOBALS['sespgDefinitionsFile'] = $GLOBALS['sespPropertyDefinitionFile'];
+			$deprecationNotices['replacement']['sespPropertyDefinitionFile'] = 'sespgDefinitionsFile';
+		}
+
+		if ( isset( $GLOBALS['sespLocalPropertyDefinitions'] ) ) {
+			$GLOBALS['sespgLocalDefinitions'] = $GLOBALS['sespLocalPropertyDefinitions'];
+			$deprecationNotices['replacement']['sespLocalPropertyDefinitions'] = 'sespgLocalDefinitions';
+		}
+
+		if ( isset( $GLOBALS['sespSpecialProperties'] ) ) {
+			$GLOBALS['sespgEnabledPropertyList'] = $GLOBALS['sespSpecialProperties'];
+			$deprecationNotices['replacement']['sespSpecialProperties'] = 'sespgEnabledPropertyList';
+		}
+
+		if ( isset( $GLOBALS['sespLabelCacheVersion'] ) ) {
+			$GLOBALS['sespgLabelCacheVersion'] = $GLOBALS['sespLabelCacheVersion'];
+			$deprecationNotices['replacement']['sespLabelCacheVersion'] = 'sespgLabelCacheVersion';
+		}
+
+		if ( isset( $GLOBALS['wgSESPExcludeBots'] ) ) {
+			$GLOBALS['sespgExcludeBotEdits'] = $GLOBALS['wgSESPExcludeBots'];
+			$deprecationNotices['replacement']['wgSESPExcludeBots'] = 'sespgExcludeBotEdits';
+		}
+
+		// Allow deprecated settings to appear on the `Special:SemanticMediaWiki`
+		// "Deprecation notices" section
+		if ( $deprecationNotices !== [] && !isset( $GLOBALS['smwgDeprecationNotices']['sesp'] ) ) {
+			$GLOBALS['smwgDeprecationNotices']['sesp'] = [ 'replacement' => $deprecationNotices['replacement'] ];
+		}
+
 		$config = [
-			'wgDisableCounters'       => $GLOBALS['wgDisableCounters'],
-			'sespUseAsFixedTables'    => $GLOBALS['sespUseAsFixedTables'],
-			'sespSpecialProperties'   => $GLOBALS['sespSpecialProperties'],
-			'wgSESPExcludeBots'       => $GLOBALS['wgSESPExcludeBots'],
-			'wgShortUrlPrefix'        => $GLOBALS['wgShortUrlPrefix'],
-			'sespPropertyDefinitionFile' => $GLOBALS['sespPropertyDefinitionFile'],
-			'sespLocalPropertyDefinitions' => $GLOBALS['sespLocalPropertyDefinitions'],
-			'sespLabelCacheVersion' => $GLOBALS['sespLabelCacheVersion'],
-			'sespPropertyDefinitions' => [],
+			'sespgUseFixedTables'      => $GLOBALS['sespgUseFixedTables'],
+			'sespgEnabledPropertyList' => $GLOBALS['sespgEnabledPropertyList'],
+			'sespgExcludeBotEdits'     => $GLOBALS['sespgExcludeBotEdits'],
+			'sespgDefinitionsFile'     => $GLOBALS['sespgDefinitionsFile'],
+			'sespgLocalDefinitions'    => $GLOBALS['sespgLocalDefinitions'],
+			'sespgLabelCacheVersion'   => $GLOBALS['sespgLabelCacheVersion'],
+
+			// Non-SESP settings
+			'wgDisableCounters'        => $GLOBALS['wgDisableCounters'],
+			'wgShortUrlPrefix'         => $GLOBALS['wgShortUrlPrefix'],
 		];
 
 		$hookRegistry = new HookRegistry(

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,10 +1,10 @@
 
 # Configuration
 
-Properties that are planned to be included need to be specified in the [`LocalSettings.php`][mw-localsettings] file using the `$GLOBALS['sespSpecialProperties']` array. By default the array is empty, i.e. no special property is being annotated to a page.
+Properties that are planned to be included need to be specified in the [`LocalSettings.php`][mw-localsettings] file using the `$GLOBALS['sespgEnabledPropertyList']` array. By default the array is empty, i.e. no special property is being annotated to a page.
 
 ```php
-$GLOBALS['sespSpecialProperties'] = array(
+$GLOBALS['sespgEnabledPropertyList'] = array(
 	'_EUSER',
 	'_CUSER',
 	...
@@ -48,14 +48,14 @@ Property labels differ according to the language the wiki was set up. An easy wa
 
 #### Fixed tables
 
-Setting `$sespUseAsFixedTables` to "true" enables to setup properties as [fixed properties][fixedprop] in order to
+Setting `$sespgUseFixedTables` to "true" enables to setup properties as [fixed properties][fixedprop] in order to
 improve data access. Doing so is recommended. Note that you have to run the [`update.php`][mw-update] from your wiki's base directory after setting this parameter for the required tables to be created.
 
-Running the [data refresh][data-refresh] afterwards is recommended as well and should be done every time a special property is added to the `$sespSpecialProperties` array.
+Running the [data refresh][data-refresh] afterwards is recommended as well and should be done every time a special property is added to the `$sespgEnabledPropertyList` array.
 
 #### Bot edits
 
-Setting `$wgSESPExcludeBots` to "true" causes bot edits via user accounts in usergroup "bot" to be ignored when storing data for the special properties activated. However this does not affect the page creator property (`_CUSER`).
+Setting `$sespgExcludeBotEdits` to "true" causes bot edits via user accounts in usergroup "bot" to be ignored when storing data for the special properties activated. However this does not affect the page creator property (`_CUSER`).
 
 #### Property definitions
 
@@ -63,7 +63,7 @@ Details about available properties can be found in the [definitions.json](/src/D
 
 #### Cache usage
 
-Setting `$sespLabelCacheVersion` to "false" will cease to use the special property label cache at all. Otherwise this is used as an internal modifier to allow resetting the cache with an arbitrary version.
+Setting `$sespgLabelCacheVersion` to "false" will cease to use the special property label cache at all. Otherwise this is used as an internal modifier to allow resetting the cache with an arbitrary version.
 
 ## Privacy
 

--- a/docs/extension.md
+++ b/docs/extension.md
@@ -7,10 +7,10 @@
 ## Repository extension
 
 The repository extension is meant to change the SESP repository itself in providing
-additional services that can be enabled via the `$sespSpecialProperties` setting.
+additional services that can be enabled via the `$sespgEnabledPropertyList` setting.
 
 ```
-$sespSpecialProperties = [
+$sespgEnabledPropertyList = [
 	'_CUSER',
 	'_VIEWS',
 	'_PAGEID',
@@ -59,7 +59,7 @@ The local extension mechanism has been introduced to avoid having to alter the `
 directly and instead provide a method for simple local adaptation.
 
 ```
-$sespSpecialProperties = [
+$sespgEnabledPropertyList = [
 	'_CUSER',
 	'_VIEWS',
 	'_PAGEID',
@@ -68,7 +68,7 @@ $sespSpecialProperties = [
 ];
 ```
 
-`$sespLocalPropertyDefinitions` contains encapsulate property definitions that
+`$sespgLocalDefinitions` contains encapsulate property definitions that
 are only valid locally to a wiki and are loaded from the `LocalSettinsg.php`.
 
 * Same fields are required as outlined in the "Repository extension" section
@@ -77,7 +77,7 @@ are only valid locally to a wiki and are loaded from the `LocalSettinsg.php`.
 **Examples**
 
 ```
-$sespLocalPropertyDefinitions['_MY_CUSTOM1'] = [
+$sespgLocalDefinitions['_MY_CUSTOM1'] = [
 	'id'    => '___MY_CUSTOM1',
 	'type'  => '_wpg',
 	'alias' => 'some-...',
@@ -88,7 +88,7 @@ $sespLocalPropertyDefinitions['_MY_CUSTOM1'] = [
 ];
 ```
 ```
-$sespLocalPropertyDefinitions['_MY_CUSTOM2'] = [
+$sespgLocalDefinitions['_MY_CUSTOM2'] = [
 	'id'    => '___MY_CUSTOM2',
 	'type'  => '_wpg',
 	'alias' => 'some-...',

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -42,5 +42,9 @@
 	"sesp-property-exif-data": "Exif data",
 	"sesp-exif-languagecode": "Exif:Language code",
 	"sesp-exif-label": "Exif:Label",
-	"sesp-exif-iimcategory": "Exif:Iim Category"
+	"sesp-exif-iimcategory": "Exif:Iim Category",
+	"sesp-admin-deprecation-notice-section": "Semantic Extra Special Properties extension",
+	"sesp-admin-deprecation-notice-title-replacement": "Replaced or renamed settings",
+	"sesp-admin-deprecation-notice-title-replacement-explanation": "The following section contains settings that were renamed or otherwise modified and it is recommended to forthwith update their name or format.",
+	"sesp-admin-deprecation-notice-config-replacement": "<code>[https://www.semantic-mediawiki.org/wiki/Extension:Semantic_Extra_Special_Properties/$1 $1]</code> was replaced by <code>[https://www.semantic-mediawiki.org/wiki/Extension:Semantic_Extra_Special_Properties/$2 $2]</code>"
 }

--- a/src/AppFactory.php
+++ b/src/AppFactory.php
@@ -137,16 +137,16 @@ class AppFactory implements LoggerAwareInterface {
 		);
 
 		$labelFetcher->setLabelCacheVersion(
-			$this->getOption( 'sespLabelCacheVersion', 0 )
+			$this->getOption( 'sespgLabelCacheVersion', 0 )
 		);
 
 		$this->propertyDefinitions = new PropertyDefinitions(
 			$labelFetcher,
-			$this->getOption( 'sespPropertyDefinitionFile' )
+			$this->getOption( 'sespgDefinitionsFile' )
 		);
 
 		$this->propertyDefinitions->setLocalPropertyDefinitions(
-			$this->getOption( 'sespLocalPropertyDefinitions', [] )
+			$this->getOption( 'sespgLocalDefinitions', [] )
 		);
 
 		return $this->propertyDefinitions;

--- a/src/ExtraPropertyAnnotator.php
+++ b/src/ExtraPropertyAnnotator.php
@@ -56,7 +56,7 @@ class ExtraPropertyAnnotator {
 
 		$propertyDefinitions = $this->appFactory->getPropertyDefinitions();
 
-		foreach ( $this->appFactory->getOption( 'sespSpecialProperties', [] ) as $key ) {
+		foreach ( $this->appFactory->getOption( 'sespgEnabledPropertyList', [] ) as $key ) {
 
 			if ( !$propertyDefinitions->deepHas( $key, 'id' ) ) {
 				continue;

--- a/src/PropertyAnnotators/LocalPropertyAnnotator.php
+++ b/src/PropertyAnnotators/LocalPropertyAnnotator.php
@@ -52,7 +52,7 @@ class LocalPropertyAnnotator implements PropertyAnnotator {
 
 		$time = microtime( true );
 
-		$localDefs = $this->appFactory->getOption( 'sespLocalPropertyDefinitions', [] );
+		$localDefs = $this->appFactory->getOption( 'sespgLocalDefinitions', [] );
 
 		foreach ( $localDefs as $key => $definition ) {
 			$this->callOnLocalDef( $definition, $property, $semanticData );

--- a/src/PropertyAnnotators/PageContributorsPropertyAnnotator.php
+++ b/src/PropertyAnnotators/PageContributorsPropertyAnnotator.php
@@ -79,7 +79,7 @@ class PageContributorsPropertyAnnotator implements PropertyAnnotator {
 	}
 
 	private function isNotAnonymous( $user ) {
-		return !( in_array( 'bot', $user->getRights() ) && $this->appFactory->getOption( 'wgSESPExcludeBots' ) ) && !$user->isAnon();
+		return !( in_array( 'bot', $user->getRights() ) && $this->appFactory->getOption( 'sespgExcludeBotEdits' ) ) && !$user->isAnon();
 	}
 
 }

--- a/src/PropertyDefinitions.php
+++ b/src/PropertyDefinitions.php
@@ -55,7 +55,7 @@ class PropertyDefinitions implements IteratorAggregate {
 		$this->propertyDefinitionFile = $propertyDefinitionFile;
 
 		if ( $this->propertyDefinitionFile === '' ) {
-			$this->propertyDefinitionFile = $GLOBALS['sespPropertyDefinitionFile'];
+			$this->propertyDefinitionFile = $GLOBALS['sespgDefinitionsFile'];
 		}
 	}
 

--- a/src/PropertyRegistry.php
+++ b/src/PropertyRegistry.php
@@ -72,14 +72,14 @@ class PropertyRegistry {
 	 */
 	public function registerFixedProperties( &$customFixedProperties, &$fixedPropertyTablePrefix ) {
 
-		if ( $this->appFactory->getOption( 'sespUseAsFixedTables' ) === false ) {
+		if ( $this->appFactory->getOption( 'sespgUseFixedTables' ) === false ) {
 			return;
 		}
 
 		$propertyDefinitions = $this->appFactory->getPropertyDefinitions();
 
 		$properties = array_flip(
-			$this->appFactory->getOption( 'sespSpecialProperties', [] )
+			$this->appFactory->getOption( 'sespgEnabledPropertyList', [] )
 		);
 
 		foreach ( $propertyDefinitions as $key => $definition ) {

--- a/tests/phpunit/Integration/DefinitionJsonFileIntegrityTest.php
+++ b/tests/phpunit/Integration/DefinitionJsonFileIntegrityTest.php
@@ -20,7 +20,7 @@ class DefinitionJsonFileIntegrityTest extends \PHPUnit_Framework_TestCase {
 		$testEnvironment = new TestEnvironment();
 
 		$jsonFileReader = $testEnvironment->getUtilityFactory()->newJsonFileReader(
-			$GLOBALS['sespPropertyDefinitionFile']
+			$GLOBALS['sespgDefinitionsFile']
 		);
 
 		$this->assertInternalType(

--- a/tests/phpunit/Unit/AppFactoryTest.php
+++ b/tests/phpunit/Unit/AppFactoryTest.php
@@ -98,8 +98,8 @@ class AppFactoryTest extends \PHPUnit_Framework_TestCase {
 	public function testGetPropertyDefinitions( ) {
 
 		$options = [
-			'sespPropertyDefinitionFile' => '',
-			'sespLocalPropertyDefinitions' => []
+			'sespgDefinitionsFile' => '',
+			'sespgLocalDefinitions' => []
 		];
 
 		$instance = new AppFactory(

--- a/tests/phpunit/Unit/ExtraPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/ExtraPropertyAnnotatorTest.php
@@ -88,7 +88,7 @@ class ExtraPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 
 		$appFactory->expects( $this->at( 1 ) )
 			->method( 'getOption' )
-			->with( $this->equalTo( 'sespSpecialProperties' ) )
+			->with( $this->equalTo( 'sespgEnabledPropertyList' ) )
 			->will( $this->returnValue( $localPropertyDefinitions ) );
 
 		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
@@ -139,7 +139,7 @@ class ExtraPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 
 		$appFactory->expects( $this->at( 1 ) )
 			->method( 'getOption' )
-			->with( $this->equalTo( 'sespSpecialProperties' ) )
+			->with( $this->equalTo( 'sespgEnabledPropertyList' ) )
 			->will( $this->returnValue( $specialProperties ) );
 
 		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )

--- a/tests/phpunit/Unit/HookRegistryTest.php
+++ b/tests/phpunit/Unit/HookRegistryTest.php
@@ -28,12 +28,12 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 	public function testRegister() {
 
 		$config = [
-			'sespPropertyDefinitionFile' => $GLOBALS['sespPropertyDefinitionFile'],
-			'sespLocalPropertyDefinitions' => [],
-			'sespSpecialProperties' => [],
+			'sespgDefinitionsFile' => $GLOBALS['sespgDefinitionsFile'],
+			'sespgLocalDefinitions' => [],
+			'sespgEnabledPropertyList' => [],
 			'wgDisableCounters' => false,
-			'sespUseAsFixedTables' => false,
-			'wgSESPExcludeBots' => false,
+			'sespgUseFixedTables' => false,
+			'sespgExcludeBotEdits' => false,
 			'wgShortUrlPrefix' => '',
 			'sespCacheType'    => 'hash'
 		];

--- a/tests/phpunit/Unit/PropertyAnnotators/LocalPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/LocalPropertyAnnotatorTest.php
@@ -67,7 +67,7 @@ class LocalPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 
 		$this->appFactory->expects( $this->once() )
 			->method( 'getOption' )
-			->with( $this->equalTo( 'sespLocalPropertyDefinitions' ) )
+			->with( $this->equalTo( 'sespgLocalDefinitions' ) )
 			->will( $this->returnValue( $localPropertyDefinitions ) );
 
 		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
@@ -97,7 +97,7 @@ class LocalPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 
 		$this->appFactory->expects( $this->once() )
 			->method( 'getOption' )
-			->with( $this->equalTo( 'sespLocalPropertyDefinitions' ) )
+			->with( $this->equalTo( 'sespgLocalDefinitions' ) )
 			->will( $this->returnValue( $localPropertyDefinitions ) );
 
 		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )

--- a/tests/phpunit/Unit/PropertyRegistryTest.php
+++ b/tests/phpunit/Unit/PropertyRegistryTest.php
@@ -152,7 +152,7 @@ class PropertyRegistryTest extends \PHPUnit_Framework_TestCase {
 
 		$this->appFactory->expects( $this->once() )
 			->method( 'getOption' )
-			->with( $this->stringContains( 'sespUseAsFixedTables' ) )
+			->with( $this->stringContains( 'sespgUseFixedTables' ) )
 			->will( $this->returnValue( false ) );
 
 		$this->appFactory->expects( $this->never() )
@@ -187,7 +187,7 @@ class PropertyRegistryTest extends \PHPUnit_Framework_TestCase {
 
 		$this->appFactory->expects( $this->at( 0 ) )
 			->method( 'getOption' )
-			->with( $this->stringContains( 'sespUseAsFixedTables' ) )
+			->with( $this->stringContains( 'sespgUseFixedTables' ) )
 			->will( $this->returnValue( true ) );
 
 		$this->appFactory->expects( $this->at( 1 ) )
@@ -196,7 +196,7 @@ class PropertyRegistryTest extends \PHPUnit_Framework_TestCase {
 
 		$this->appFactory->expects( $this->at( 2 ) )
 			->method( 'getOption' )
-			->with( $this->stringContains( 'sespSpecialProperties' ) )
+			->with( $this->stringContains( 'sespgEnabledPropertyList' ) )
 			->will( $this->returnValue( [ 'Foo' ] ) );
 
 		$instance = new PropertyRegistry(


### PR DESCRIPTION
This PR is made in reference to: #92

This PR addresses or contains:

- Renames settings according to #92 but keeps the legacy settings to avoid BC
- Deprecated settings will appear on the `Special:SemanticMediaWiki` section

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

### Example

![image](https://user-images.githubusercontent.com/1245473/46258254-bdab1d00-c4b6-11e8-8f0a-d7100ba77205.png)

