### PR TITLE
Support `sesp.group.json` (PROPERTY_GROUP_SCHEMA)

### DIFF
--- a/data/definitions.json
+++ b/data/definitions.json
@@ -528,7 +528,7 @@
 			"id": "___EXIFIMAGEUNIQUEID",
 			"type": "_txt",
 			"alias": "exif-imageuniqueid",
-			"label": "Exif:Image unique i d"
+			"label": "Exif:Image unique id"
 		},
 		"SPECTRALSENSITIVITY": {
 			"id": "___EXIFSPECTRALSENSITIVITY",
@@ -546,7 +546,7 @@
 			"id": "___EXIFGPSVERSIONID",
 			"type": "_txt",
 			"alias": "exif-gpsversionid",
-			"label": "Exif:Gps version i d"
+			"label": "Exif:Gps version id"
 		},
 		"GPSMAPDATUM": {
 			"id": "___EXIFGPSMAPDATUM",

--- a/data/import/groups/exif.group.json
+++ b/data/import/groups/exif.group.json
@@ -1,0 +1,146 @@
+{
+    "type": "PROPERTY_GROUP_SCHEMA",
+    "description": "Provides groups for EXIF related properties provided by the `Semantic Extra Special Properties` extension.",
+    "groups": [
+        {
+            "group_name":"Exif (Dimension and resolution)",
+            "message_key": "sesp-property-group-label-exif-dimension-group",
+            "properties": [
+                "___EXIFIMAGEWIDTH",
+                "___EXIFIMAGELENGTH",
+                "___EXIFORIGINALIMAGEHEIGHT",
+                "___EXIFORIGINALIMAGEWIDTH",
+                "___EXIFXRESOLUTION",
+                "___EXIFYRESOLUTION",
+                "___EXIFPIXELXDIMENSION",
+                "___EXIFPIXELYDIMENSION"
+            ]
+        },
+        {
+            "group_name":"Exif (Administrative)",
+            "message_key": "sesp-property-group-label-exif-meta-group",
+            "properties": [
+                "___EXIFSOFTWARE",
+                "___EXIFDATETIME",
+                "___EXIFEXIFVERSION",
+                "___EXIFDATETIMEMETADATA",
+                "___EXIFCOPYRIGHT",
+                "___EXIFCOPYRIGHTOWNER",
+                "___EXIFCOPYRIGHTED",
+                "___EXIFARTIST",
+                "___EXIFDATETIMERELEASED",
+                "___EXIFDATETIMEEXPIRES",
+                "___EXIFOBJECTNAME",
+                "___EXIFHEADLINE",
+                "___EXIFCREDIT",
+                "___EXIFSOURCE",
+                "___EXIFWRITER",
+                "___EXIFIDENTIFIER",
+                "___EXIFSERIALNUMBER",
+                "___EXIFCAMERAOWNERNAME",
+                "___EXIFNICKNAME",
+                "___EXIFLANGUAGECODE",
+                "___EXIFDATETIMEDIGITIZED",
+                "___EXIFDATETIMEORIGINAL",
+                "___EXIFFILESOURCE",
+                "___EXIFJPEGFILECOMMENT",
+                "___EXIFPNGFILECOMMENT",
+                "___EXIFGIFFILECOMMENT",
+                "___EXIFCUSTOMRENDERED"
+            ]
+        },
+        {
+            "group_name":"Exif (Classification)",
+            "message_key": "sesp-property-group-label-exif-classification-group",
+            "properties": [
+                "___EXIFIIMCATEGORY",
+                "___EXIFIIMSUPPLEMENTALCATEGORY",
+                "___EXIFKEYWORDS",
+                "___EXIFINTELLECTUALGENRE"
+            ]
+        },
+        {
+            "group_name":"Exif (Camera and lense)",
+            "message_key": "sesp-property-group-label-exif-camera-lense-settings-group",
+            "properties": [
+                "___EXIFMAKE",
+                "___EXIFMODEL",
+                "___EXIFYCBCRPOSITIONING",
+                "___EXIFCOMOPRESSION",
+                "___EXIFCOMPONENTSCONFIGURATION",
+                "___EXIFMETERINGMODE",
+                "___EXIFFLASH",
+                "___EXIFFLASHPIXVERSION",
+                "___EXIFLENS",
+                "___EXIFFOCALLENGTH",
+                "___EXIFFOCALLENGTHIN35MMFILM",
+                "___EXIFCOLORSPACE",
+                "___EXIFISOSPEEDRATINGS",
+                "___EXIFWHITEBALANCE",
+                "___EXIFLIGHTSOURCE",
+                "___EXIFSENSINGMETHOD",
+                "___EXIFORIENTATION"
+            ]
+        },
+        {
+            "group_name":"Exif (Exposure)",
+            "message_key": "sesp-property-group-label-exif-exposure-group",
+            "properties": [
+                "___EXIFEXPOSURETIME",
+                "___EXIFFNUMBER",
+                "___EXIFEXPOSUREPROGRAM",
+                "___EXIFMAXAPERTUREVALUE",
+                "___EXIFCONTRAST",
+                "___EXIFSATURATION",
+                "___EXIFSHARPNESS",
+                "___EXIFEXPOSUREMODE"
+            ]
+        },
+        {
+            "group_name":"Exif (Scene)",
+            "message_key": "sesp-property-group-label-exif-scene-group",
+            "properties": [
+                "___EXIFSCENECODE",
+                "___EXIFSCENETYPE",
+                "___EXIFSCENECAPTURETYPE",
+                "___EXIFGAINCONTROL"
+            ]
+        },
+        {
+            "group_name":"Exif (Location)",
+            "message_key": "sesp-property-group-label-exif-location-group",
+            "properties": [
+                "___EXIFWORLDREGIONDEST",
+                "___EXIFWORLDREGIONCREATED",
+                "___EXIFCOUNTRYDEST",
+                "___EXIFCOUNTRYCREATED",
+                "___EXIFCOUNTRYCODEDEST",
+                "___EXIFCOUNTRYCODECREATED",
+                "___EXIFPROVINCEORSTATEDEST",
+                "___EXIFPROVINCEORSTATECREATED",
+                "___EXIFCITYDEST",
+                "___EXIFCITYCREATED",
+                "___EXIFSUBLOCATIONDEST",
+                "___EXIFSUBLOCATIONCREATED",
+                "___EXIFLOCATIONDEST",
+                "___EXIFLOCATIONDESTCODE"
+            ]
+        },
+        {
+            "group_name":"Exif (Location, GPS)",
+            "message_key": "sesp-property-group-label-exif-gps-group",
+            "properties": [
+                "___EXIFGPSSATELLITES",
+                "___EXIFGPSVERSIONID",
+                "___EXIFGPSMAPDATUM",
+                "___EXIFGPSDATESTAMP"
+            ]
+        }
+    ],
+    "tags": [
+        "group",
+        "property group",
+        "exif special properties",
+        "extra special properties"
+    ]
+}

--- a/data/import/groups/extra.group.json
+++ b/data/import/groups/extra.group.json
@@ -1,0 +1,37 @@
+{
+    "type": "PROPERTY_GROUP_SCHEMA",
+    "description": "Provides groups for special properties provided by the `Semantic Extra Special Properties` extension.",
+    "groups": [
+        {
+            "group_name":"User related",
+            "message_key": "sesp-property-group-label-user-data-group",
+            "properties": [
+                "___USERREG",
+                "___USEREDITCNT",
+                "___USERBLOCK",
+                "___USERRIGHT",
+                "___USERGROUP"
+            ]
+        },
+        {
+            "group_name":"Page related",
+            "message_key": "sesp-property-group-label-page-data-group",
+            "properties": [
+                "___REVID",
+                "___PAGEID",
+                "___PAGELGTH",
+                "___EUSER",
+                "___CUSER",
+                "___VIEWS",
+                "___SUBP",
+                "___NREV",
+                "___NTREV"
+            ]
+        }
+    ],
+    "tags": [
+        "group",
+        "property group",
+        "extra special properties"
+    ]
+}

--- a/data/import/sesp.groups.json
+++ b/data/import/sesp.groups.json
@@ -1,0 +1,28 @@
+{
+	"description": "Semantic Extra Special Properties import",
+	"import": [
+		{
+			"page": "Group:Extra special properties",
+			"namespace": "SMW_NS_SCHEMA",
+			"contents": {
+				"importFrom": "/groups/extra.group.json"
+			},
+			"options": {
+				"replaceable": { "LAST_EDITOR": "IS_IMPORTER" }
+			}
+		},
+		{
+			"page": "Group:Exif special properties",
+			"namespace": "SMW_NS_SCHEMA",
+			"contents": {
+				"importFrom": "/groups/exif.group.json"
+			},
+			"options": {
+				"replaceable": { "LAST_EDITOR": "IS_IMPORTER" }
+			}
+		}
+	],
+	"meta": {
+		"version": "1"
+	}
+}

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -114,6 +114,10 @@ class HookRegistry {
 				);
 			}
 
+			if ( isset( $config['smwgImportFileDirs'] ) ) {
+				$config['smwgImportFileDirs'] += [ 'sesp' => __DIR__ . '/../data/import' ];
+			}
+
 			return true;
 		};
 	}


### PR DESCRIPTION
This PR is made in reference to: https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3749, https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/4045

This PR addresses or contains:

- Adds `sesp.groups.json` and will be automatically be imported as part of the SMW setup

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

### Example

```
Import of smw.groups.json ...
   ... replacing smw/schema:Group:Schema properties
       importer was last editor ...
   ... done.

Import of smw.vocab.json ...
   ... skipping MediaWiki:Smw import skos
       already exists ...
   ... skipping MediaWiki:Smw import foaf
       already exists ...
   ... skipping MediaWiki:Smw import owl
       already exists ...
   ... skipping Property:Foaf:knows
       already exists ...
   ... skipping Property:Foaf:name
       already exists ...
   ... skipping Property:Foaf:homepage
       already exists ...
   ... skipping Property:Owl:differentFrom
       already exists ...
   ... done.

Import of sar.groups.json ...
   ... replacing smw/schema:Group:Approved revs properties
       importer was last editor ...
   ... done.

Import of sesp.groups.json ...
   ... replacing smw/schema:Group:Extra special properties
       importer was last editor ...
   ... replacing smw/schema:Group:Exif special properties
       importer was last editor ...
   ... done.
```
