### PR TITLE
Replace deprecated DB_SLAVE constant

### DIFF
--- a/src/AppFactory.php
+++ b/src/AppFactory.php
@@ -72,7 +72,7 @@ class AppFactory implements LoggerAwareInterface {
 	public function getConnection() {
 
 		if ( $this->connection === null ) {
-			$this->connection = wfGetDB( DB_SLAVE );
+			$this->connection = wfGetDB( DB_REPLICA );
 		}
 
 		return $this->connection;


### PR DESCRIPTION
This constant was renamed to DB_REPLICA and remained as deprecated alias since MW 1.28.

It was completely [dropped in MW 1.34](https://gerrit.wikimedia.org/r/#/c/mediawiki/core/+/443747/)

Fixes #124