### PR TITLE
typo in migration documentation

### DIFF
--- a/docs/migration-to-200.md
+++ b/docs/migration-to-200.md
@@ -8,7 +8,7 @@ and their new replacements:
 1. `$sespUseAsFixedTables` was changed to `$sespgUseFixedTables`
 2. `$sespPropertyDefinitionFile` was changed to `$sespgDefinitionsFile`
 3. `$sespLocalPropertyDefinitions` was changed to `$sespgLocalDefinitions`
-4. `$sespSpecialProperties` was changed to `$sespgEnabledPropertiesList`
+4. `$sespSpecialProperties` was changed to `$sespgEnabledPropertyList`
 5. `$sespLabelCacheVersion` was changed to `$sespgLabelCacheVersion`
 6. `$wgSESPExcludeBots` was changed to `$sespgExcludeBotEdits`
 


### PR DESCRIPTION
must be "sespgEnabledPropertyList", according to https://github.com/SemanticMediaWiki/SemanticExtraSpecialProperties/blob/15f4547d46fcb8ec3fffbfb1bc064f1b5002beaf/SemanticExtraSpecialProperties.php#L117


