### PR TITLE
Fix warnings and notices issued by travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
-# http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+# https://docs.travis-ci.com/user/reference/overview/
 language: php
-sudo: false
 
-# Travis support wrote "Ubuntu 14.04 reached EOL on April 30th, 2019,
-# ... we've been slowly rolling out changes to make Xenial builds ..."
-# https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment
-# https://docs.travis-ci.com/user/reference/xenial/#services-disabled-by-default.
+os:
+  - linux
+
+dist: xenial 
+
 services:
   - mysql
   
-matrix:
+jobs:
   fast_finish: true
   include:
     - env: DB=sqlite; MW=REL1_31; PHPUNIT=5.7.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ language: php
 os:
   - linux
 
-dist: xenial 
-
 services:
   - mysql
   


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains fixes for:
- root: deprecated key sudo (The key `sudo` has no effect anymore.)
- root: key matrix is an alias for jobs, using jobs
- root: missing os, using the default linux

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #
