### PR TITLE
exif.group.json - Update the underlying schema for SMW 3.2.

### DIFF
--- a/data/import/groups/exif.group.json
+++ b/data/import/groups/exif.group.json
@@ -1,11 +1,13 @@
 {
     "type": "PROPERTY_GROUP_SCHEMA",
     "description": "Provides groups for EXIF related properties provided by the `Semantic Extra Special Properties` extension.",
-    "groups": [
+    "groups": 
+	{
+		"Exif (Dimension and resolution)_group":
         {
-            "group_name":"Exif (Dimension and resolution)",
+            "canonical_name":"Exif (Dimension and resolution)",
             "message_key": "sesp-property-group-label-exif-dimension-group",
-            "properties": [
+            "property_keys": [
                 "___EXIFIMAGEWIDTH",
                 "___EXIFIMAGELENGTH",
                 "___EXIFORIGINALIMAGEHEIGHT",
@@ -16,10 +18,11 @@
                 "___EXIFPIXELYDIMENSION"
             ]
         },
+		"Exif (Administrative)_group":
         {
-            "group_name":"Exif (Administrative)",
+            "canonical_name":"Exif (Administrative)",
             "message_key": "sesp-property-group-label-exif-meta-group",
-            "properties": [
+            "property_keys": [
                 "___EXIFSOFTWARE",
                 "___EXIFDATETIME",
                 "___EXIFEXIFVERSION",
@@ -49,20 +52,22 @@
                 "___EXIFCUSTOMRENDERED"
             ]
         },
+		"Exif (Classification)_group":
         {
-            "group_name":"Exif (Classification)",
+            "canonical_name":"Exif (Classification)",
             "message_key": "sesp-property-group-label-exif-classification-group",
-            "properties": [
+            "property_keys": [
                 "___EXIFIIMCATEGORY",
                 "___EXIFIIMSUPPLEMENTALCATEGORY",
                 "___EXIFKEYWORDS",
                 "___EXIFINTELLECTUALGENRE"
             ]
         },
+		"Exif (Camera and lense)_group":
         {
-            "group_name":"Exif (Camera and lense)",
+            "canonical_name":"Exif (Camera and lense)",
             "message_key": "sesp-property-group-label-exif-camera-lense-settings-group",
-            "properties": [
+            "property_keys": [
                 "___EXIFMAKE",
                 "___EXIFMODEL",
                 "___EXIFYCBCRPOSITIONING",
@@ -82,10 +87,11 @@
                 "___EXIFORIENTATION"
             ]
         },
+		"Exif (Exposure)_group":
         {
-            "group_name":"Exif (Exposure)",
+            "canonical_name":"Exif (Exposure)",
             "message_key": "sesp-property-group-label-exif-exposure-group",
-            "properties": [
+            "property_keys": [
                 "___EXIFEXPOSURETIME",
                 "___EXIFFNUMBER",
                 "___EXIFEXPOSUREPROGRAM",
@@ -96,20 +102,22 @@
                 "___EXIFEXPOSUREMODE"
             ]
         },
+		"Exif (Scene)_group":
         {
-            "group_name":"Exif (Scene)",
+            "canonical_name":"Exif (Scene)",
             "message_key": "sesp-property-group-label-exif-scene-group",
-            "properties": [
+            "property_keys": [
                 "___EXIFSCENECODE",
                 "___EXIFSCENETYPE",
                 "___EXIFSCENECAPTURETYPE",
                 "___EXIFGAINCONTROL"
             ]
         },
+		"Exif (Location)_group":
         {
-            "group_name":"Exif (Location)",
+            "canonical_name":"Exif (Location)",
             "message_key": "sesp-property-group-label-exif-location-group",
-            "properties": [
+            "property_keys": [
                 "___EXIFWORLDREGIONDEST",
                 "___EXIFWORLDREGIONCREATED",
                 "___EXIFCOUNTRYDEST",
@@ -126,17 +134,18 @@
                 "___EXIFLOCATIONDESTCODE"
             ]
         },
+		"Exif (Location, GPS)_group":
         {
-            "group_name":"Exif (Location, GPS)",
+            "canonical_name":"Exif (Location, GPS)",
             "message_key": "sesp-property-group-label-exif-gps-group",
-            "properties": [
+            "property_keys": [
                 "___EXIFGPSSATELLITES",
                 "___EXIFGPSVERSIONID",
                 "___EXIFGPSMAPDATUM",
                 "___EXIFGPSDATESTAMP"
             ]
         }
-    ],
+    },
     "tags": [
         "group",
         "property group",


### PR DESCRIPTION
According to https://www.semantic-mediawiki.org/wiki/Help:Schema/Type/PROPERTY_GROUP_SCHEMA: "The underlying schema changed between it's initial release with Semantic MediaWiki 3.1.0 and Semantic MediaWiki 3.2.0.23 Thus you need to migrate existing schemas to the new structure."