### PR TITLE
Update definitions.json

### DIFF
--- a/data/definitions.json
+++ b/data/definitions.json
@@ -909,6 +909,24 @@
 			"type": "_txt",
 			"alias": "sesp-exif-languagecode",
 			"label": "Exif:Language code"
-		}
+		},
+                "GPSLATITUDE": {
+                        "id": "___EXIFGPSLATITUDE",
+                        "type": "_txt",
+                        "alias": "sesp-exif-gpslatitude",
+                        "label": "Exif:GPSLatitude"
+                },
+                "GPSLONGITUDE": {
+                        "id": "___EXIFGPSLONGITUDE",
+                        "type": "_txt",
+                        "alias": "sesp-exif-gpslongitude",
+                        "label": "Exif:GPSLongitude"
+                },
+                "GPSALTITUDE": {
+                        "id": "___EXIFGPSALTITUDE",
+                        "type": "_txt",
+                        "alias": "sesp-exif-gpsaltitude",
+                        "label": "Exif:GPSAltitude"
+                }
 	}
 }


### PR DESCRIPTION
add basic GPS exif data according to https://www.mediawiki.org/wiki/MediaWiki:Metadata-fields
(up to now the last three have been missing

This PR is made in reference to: #155

This PR addresses or contains:
- update of definition.json
- update of qqq.json for translations

