### PR TITLE
Move Hook registration out of init callback and into SetupAfterCache

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -65,6 +65,9 @@
 			"descrirptionmsg": "sesp-config-exclude-bot-edits"
 		}
 	},
+	"Hooks": {
+		"SetupAfterCache": "SESP\\Hook::onSetupAfterCache"
+	},
 	"load_composer_autoloader": true,
 	"manifest_version": 2
 }

--- a/src/Hook.php
+++ b/src/Hook.php
@@ -68,7 +68,9 @@ class Hook {
 				'replacement' => $deprecationNotices['replacement']
 			];
 		}
+	}
 
+	public static function onSetupAfterCache() {
 		$config = [
 			'sespgUseFixedTables'      => $GLOBALS['sespgUseFixedTables'],
 			'sespgEnabledPropertyList' => $GLOBALS['sespgEnabledPropertyList'],


### PR DESCRIPTION
SetupAfterCache is the first available hook after  MW_SERVICE_BOOTSTRAP_COMPLETE is defined and
registering hooks before this point results in a deprecation warning:

    Deprecated: Registering handler for * before MediaWiki bootstrap
	complete was deprecated in MediaWiki 1.35

Fixes #189

- [x] CI build passed
