### PR TITLE
fix SESP\PropertyDefinitions::getIterator()  error

### DIFF
--- a/src/PropertyDefinitions.php
+++ b/src/PropertyDefinitions.php
@@ -4,6 +4,7 @@ namespace SESP;
 
 use ArrayIterator;
 use InvalidArgumentException;
+use Iterator;
 use IteratorAggregate;
 use MediaWiki\MediaWikiServices;
 use Onoi\Cache\Cache;
@@ -192,7 +193,7 @@ class PropertyDefinitions implements IteratorAggregate {
 	 *
 	 * @return Iterator
 	 */
-	public function getIterator() {
+	public function getIterator(): Iterator {
 
 		if ( $this->propertyDefinitions === null ) {
 			$this->initPropertyDefinitions();


### PR DESCRIPTION
SMW: 4.1.1
SESP :3.0.4
MW: 1.39.3


Fixes error

`
<b>Deprecated</b>:  Return type of SESP\PropertyDefinitions::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice ...`

this prevents SMW's `Special:ExportRDF` from working (with deprecation warnings enabled)



