### PR TITLE
Fixes #223 Use of Hooks::register was deprecated in MediaWiki 1.35

### DIFF
--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -34,7 +34,7 @@ class HookRegistry {
 	public function register() {
 		$hookContainer = MediaWikiServices::getInstance()->getHookContainer();
 		foreach ( $this->handlers as $name => $callback ) {
-			$hookContainer->register( $name,  $callback);
+			$hookContainer->register( $name, $callback );
 		}
 	}
 

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -32,8 +32,9 @@ class HookRegistry {
 	 * @since  1.0
 	 */
 	public function register() {
+		$hookContainer = MediaWikiServices::getInstance()->getHookContainer();
 		foreach ( $this->handlers as $name => $callback ) {
-			Hooks::register( $name, $callback );
+			$hookContainer->register( $name, [ $this, $callback ]);
 		}
 	}
 

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -34,7 +34,7 @@ class HookRegistry {
 	public function register() {
 		$hookContainer = MediaWikiServices::getInstance()->getHookContainer();
 		foreach ( $this->handlers as $name => $callback ) {
-			$hookContainer->register( $name, [ $this, $callback ]);
+			$hookContainer->register( $name,  $callback);
 		}
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #223

