### PR TITLE
USEREDITCNTNS compatibility with MW1.39

### DIFF
--- a/src/PropertyAnnotators/UserEditCountPerNsPropertyAnnotator.php
+++ b/src/PropertyAnnotators/UserEditCountPerNsPropertyAnnotator.php
@@ -2,7 +2,6 @@
 
 namespace SESP\PropertyAnnotators;
 
-use MediaWiki\MediaWikiServices;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
 use SMW\DIProperty;
@@ -120,8 +119,8 @@ class UserEditCountPerNsPropertyAnnotator implements PropertyAnnotator {
 		if ( version_compare( MW_VERSION, "1.39", ">=" ) ) {
 			$queryTables = [ 'revision', 'actor', 'page' ];
 			$joinConditions = [
-				'page'	=> [ 'INNER JOIN', ['page.page_id=revision.rev_page'] ],
-				'actor'	=> [ 'INNER JOIN', ['actor.actor_id=revision.rev_actor'] ]
+				'page'	=> [ 'INNER JOIN', [ 'page.page_id=revision.rev_page' ] ],
+				'actor'	=> [ 'INNER JOIN', [ 'actor.actor_id=revision.rev_actor' ] ]
 			];
 		} else {
 			$queryTables = [ 'revision', 'revision_actor_temp', 'actor', 'page' ];


### PR DESCRIPTION
This PR is made in reference to: https://github.com/SemanticMediaWiki/SemanticExtraSpecialProperties/issues/233

This PR addresses or contains:
- a check on the version of the MediaWiki installation, after which the query takes into account changes made in the database schema of MediaWiki version 1.39

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes https://github.com/SemanticMediaWiki/SemanticExtraSpecialProperties/issues/233
