### PR TITLE
Use select query builder and use database prefix

### DIFF
--- a/src/PropertyAnnotators/UserEditCountPerNsPropertyAnnotator.php
+++ b/src/PropertyAnnotators/UserEditCountPerNsPropertyAnnotator.php
@@ -114,7 +114,7 @@ class UserEditCountPerNsPropertyAnnotator implements PropertyAnnotator {
 	 * @return int[] An associative array NS number => revision count
 	 */
 	private function getEditsPerNs( $id, $ip ): array {
-		$db = wfGetDB( DB_REPLICA );
+		$db = $this->appFactory->getConnection();
 		$queryTables = [ 'revision', 'actor', 'page' ];
 
 		if ( version_compare( MW_VERSION, '1.39', '>=' ) ) {

--- a/src/PropertyAnnotators/UserEditCountPerNsPropertyAnnotator.php
+++ b/src/PropertyAnnotators/UserEditCountPerNsPropertyAnnotator.php
@@ -128,16 +128,25 @@ class UserEditCountPerNsPropertyAnnotator implements PropertyAnnotator {
 		} else {
 			$queryTables = [ "revision", "revision_actor_temp", "actor", "page" ];
 			$joinConditions = [
-				"page"					=> [ 'INNER JOIN', [ "{$dbPrefix}page.page_id={$dbPrefix}revision.rev_page" ] ],
-				"revision_actor_temp"	=> [ 'INNER JOIN', [ "{$dbPrefix}revision_actor_temp.revactor_rev={$dbPrefix}revision.rev_id" ] ],
-				"actor"					=> [ 'INNER JOIN', [ "{$dbPrefix}actor.actor_id={$dbPrefix}revision_actor_temp.revactor_actor" ] ]
+				"page"					=> [ 'INNER JOIN', [
+					"{$dbPrefix}page.page_id={$dbPrefix}revision.rev_page"
+				] ],
+				"revision_actor_temp"	=> [ 'INNER JOIN', [
+					"{$dbPrefix}revision_actor_temp.revactor_rev={$dbPrefix}revision.rev_id"
+				] ],
+				"actor"					=> [ 'INNER JOIN', [
+					"{$dbPrefix}actor.actor_id={$dbPrefix}revision_actor_temp.revactor_actor"
+				] ]
 			];
 		}
 
 		$result = $dbr->newSelectQueryBuilder()
 			->select( [ 'ns' => "{$dbPrefix}page.page_namespace", 'edits' => "COUNT({$dbPrefix}revision.rev_id)" ] )
 			->tables( $queryTables )
-			->where( $id === null ? [ "{$dbPrefix}actor.actor_name" => $ip ] : [ "{$dbPrefix}actor.actor_user" => $id ] )
+			->where( $id === null
+				? [ "{$dbPrefix}actor.actor_name" => $ip ]
+				: [ "{$dbPrefix}actor.actor_user" => $id ]
+			)
 			->groupBy( "{$dbPrefix}page.page_namespace" )
 			->joinConds( $joinConditions )
 			->caller( __METHOD__ )


### PR DESCRIPTION
This PR is made in reference to: #237 

This PR addresses or contains:
- uses the MediaWiki SelectQueryBuilder to construct the query
- inserts the database prefix (if configured) into the clauses for the SELECT, WHERE, and JOIN conditions

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #237 
