### PR TITLE
Really try to go around the now private HookContainer::getHandlers() method.

### DIFF
--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -75,7 +75,7 @@ class HookRegistry {
 	public function getHandlers( $name ) {
 		$container = MediaWikiServices::getInstance()->getHookContainer();
 		$hook = 'SMW::Property::initProperties';
-		return method_exists( 'HookContainer', 'getHandlerCallbacks' )
+		return method_exists( $container, 'getHandlerCallbacks' )
 			? $container->getHandlerCallbacks( $hook )
 			: $container->getHandlers( $hook );
 	}


### PR DESCRIPTION
Really try to go around the now private HookContainer::getHandlers() method.