### PR TITLE
Fix typo causing a test for MW 1.41 to fail

### DIFF
--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -75,10 +75,9 @@ class HookRegistry {
 	 */
 	public function getHandlers( $name ) {
 		$container = MediaWikiServices::getInstance()->getHookContainer();
-		$hook = 'SMW::Property::initProperties';
 		return method_exists( $container, 'getHandlerCallbacks' )
-			? $container->getHandlerCallbacks( $hook )
-			: $container->getHandlers( $hook );
+			? $container->getHandlerCallbacks( $name )
+			: $container->getHandlers( $name );
 	}
 
 	/**


### PR DESCRIPTION
Fix typo causing a test for MW 1.41 to fail.