### PR TITLE
fix(Links to): incorrect definition for _LINKSTO

### DIFF
--- a/data/definitions.json
+++ b/data/definitions.json
@@ -962,7 +962,7 @@
 				"type": "_txt",
 				"alias": "sesp-exif-gpsaltitude",
 				"label": "Exif:GPSAltitude"
-		},
+		}
 	},
 	"_LINKSTO": {
 		"id": "___LINKSTO",

--- a/data/definitions.json
+++ b/data/definitions.json
@@ -963,11 +963,11 @@
 				"alias": "sesp-exif-gpsaltitude",
 				"label": "Exif:GPSAltitude"
 		},
-		"LINKSTO": {
-			"id": "___LINKSTO",
-			"type": "_wpg",
-			"alias": "sesp-property-links-to",
-			"label": "Links to"
-		}
+	},
+	"_LINKSTO": {
+		"id": "___LINKSTO",
+		"type": "_wpg",
+		"alias": "sesp-property-links-to",
+		"label": "Links to"
 	}
 }


### PR DESCRIPTION
The previous definition for `_LINKSTO` was incorrect. It was contained within `_EXIF` and has the wrong key.
