### PR TITLE
implement newer database access method

### DIFF
--- a/src/AppFactory.php
+++ b/src/AppFactory.php
@@ -72,7 +72,11 @@ class AppFactory implements LoggerAwareInterface {
 	 */
 	public function getConnection() {
 		if ( $this->connection === null ) {
-			$this->connection = wfGetDB( DB_REPLICA );
+			if ( version_compare( MW_VERSION, '1.42', '>=' ) ) {
+				$this->connection = MediaWikiServices::getInstance()->getConnectionProvider()->getReplicaDatabase();
+			} else {
+				$this->connection = MediaWikiServices::getInstance()->getDBLoadBalancer()->getConnection( DB_REPLICA );
+			}
 		}
 
 		return $this->connection;

--- a/src/PropertyAnnotators/ApprovedDatePropertyAnnotator.php
+++ b/src/PropertyAnnotators/ApprovedDatePropertyAnnotator.php
@@ -63,8 +63,13 @@ class ApprovedDatePropertyAnnotator implements PropertyAnnotator {
 			// ApprovedRevs does not provide a function to get the approval date,
 			// so fetch it here from the ApprovedRevs table
 			$pageID = $semanticData->getSubject()->getTitle()->getArticleID();
-			$dbr = wfGetDB( DB_REPLICA );
-			$approval_date = $dbr->selectField( 'approved_revs', 'approval_date', [ 'page_id' => $pageID ] );
+			$dbr = $this->appFactory->getConnection();
+			if ( $dbr ) {
+				$approval_date = $dbr->selectField( 'approved_revs', 'approval_date', [ 'page_id' => $pageID ] );
+			} else {
+				// Handle the error appropriately, e.g., log an error or throw an exception
+				throw new \RuntimeException( 'Database connection failed.' );
+			}
 
 			if ( $approval_date ) {
 				$this->approvedDate = new MWTimestamp( wfTimestamp( TS_MW, $approval_date ) );


### PR DESCRIPTION
wfGetDB() was deprecated as of REL1_39
and is being removed in REL1_44

This PR is made in reference to: #253 

This PR addresses or contains:
- modify AppFactory->getConnection to be version aware
- use `MediaWikiServices::getInstance()->getConnectionProvider()->getReplicaDatabase()` in 1.42+
- when creating a db handle in src/PropertyAnnotators/ApprovedDatePropertyAnnotator.php, use `$this->appFactory->getConnection()` instead of wfGetDB()
- maybe throwing a db connection exception in annotator class methods is a code smell and getConnection should handle it?

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #253 
