### PR TITLE
Refactor missing class aliases

### DIFF
--- a/src/LabelFetcher.php
+++ b/src/LabelFetcher.php
@@ -4,7 +4,7 @@ namespace SESP;
 
 use Onoi\Cache\Cache;
 use Onoi\Cache\NullCache;
-use SMW\Message;
+use SMW\Localizer\Message;
 
 /**
  * @ingroup SESP

--- a/src/PropertyAnnotators/ExifPropertyAnnotator.php
+++ b/src/PropertyAnnotators/ExifPropertyAnnotator.php
@@ -8,7 +8,7 @@ use SESP\PropertyAnnotator;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\SemanticData;
-use SMWContainerSemanticData as ContainerSemanticData;
+use SMW\DataModel\ContainerSemanticData as ContainerSemanticData;
 use SMWDataItem as DataItem;
 use SMWDIBlob as DIBlob;
 use SMWDIContainer as DIContainer;

--- a/src/PropertyAnnotators/UserEditCountPerNsPropertyAnnotator.php
+++ b/src/PropertyAnnotators/UserEditCountPerNsPropertyAnnotator.php
@@ -7,7 +7,7 @@ use SESP\PropertyAnnotator;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\SemanticData;
-use SMWContainerSemanticData as ContainerSemanticData;
+use SMW\DataModel\ContainerSemanticData as ContainerSemanticData;
 use SMWDataItem as DataItem;
 use SMWDIContainer as DIContainer;
 use SMWDINumber as DINumber;


### PR DESCRIPTION
Some aliases have been removed in https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6044

This change update the respective class names.
