### PR TITLE
Use explicit nullable type on parameter arguments (for PHP 8.4)

### DIFF
--- a/src/AppFactory.php
+++ b/src/AppFactory.php
@@ -53,7 +53,7 @@ class AppFactory implements LoggerAwareInterface {
 	 * @param array $options
 	 * @param Cache|null $cache
 	 */
-	public function __construct( array $options = [], Cache $cache = null ) {
+	public function __construct( array $options = [], ?Cache $cache = null ) {
 		$this->options = $options;
 		$this->cache = $cache;
 	}
@@ -205,7 +205,7 @@ class AppFactory implements LoggerAwareInterface {
 	 * @param string $type which log entries to get (default: approval)
 	 * @return DatabaseLogReader
 	 */
-	public function newDatabaseLogReader( Title $title = null, $type = 'approval' ) {
+	public function newDatabaseLogReader( ?Title $title = null, $type = 'approval' ) {
 		return new DatabaseLogReader( $this->getConnection(), $title, $type );
 	}
 }

--- a/src/DatabaseLogReader.php
+++ b/src/DatabaseLogReader.php
@@ -48,7 +48,7 @@ class DatabaseLogReader {
 	 * @param Title|null $title
 	 * @param string $type of log (default: approval)
 	 */
-	public function __construct( $dbr, Title $title = null, $type = 'approval' ) {
+	public function __construct( $dbr, ?Title $title = null, $type = 'approval' ) {
 		// Due to MW 1.31+ and MW 1.34+
 		if (
 			!$dbr instanceof \Wikimedia\Rdbms\IDatabase &&

--- a/src/LabelFetcher.php
+++ b/src/LabelFetcher.php
@@ -42,7 +42,7 @@ class LabelFetcher {
 	 * @param Cache|null $cache
 	 * @param string $languageCode
 	 */
-	public function __construct( Cache $cache = null, $languageCode = 'en' ) {
+	public function __construct( ?Cache $cache = null, $languageCode = 'en' ) {
 		$this->cache = $cache;
 		$this->languageCode = $languageCode;
 


### PR DESCRIPTION
Implicitly marking parameter $... as nullable is deprecated in PHP 8.4. The explicit nullable type must be used instead.