### PR TITLE
Give __METHOD__ to estimateRowCount to prevent warning 'SQL query did not specify the caller'

### DIFF
--- a/src/PropertyAnnotators/PageNumRevisionPropertyAnnotator.php
+++ b/src/PropertyAnnotators/PageNumRevisionPropertyAnnotator.php
@@ -75,7 +75,8 @@ class PageNumRevisionPropertyAnnotator implements PropertyAnnotator {
 		return $this->appFactory->getConnection()->estimateRowCount(
 			"revision",
 			"*",
-			[ "rev_page" => $pageId ]
+			[ "rev_page" => $pageId ],
+			__METHOD__
 		);
 	}
 

--- a/src/PropertyAnnotators/TalkPageNumRevisionPropertyAnnotator.php
+++ b/src/PropertyAnnotators/TalkPageNumRevisionPropertyAnnotator.php
@@ -75,7 +75,8 @@ class TalkPageNumRevisionPropertyAnnotator implements PropertyAnnotator {
 		return $this->appFactory->getConnection()->estimateRowCount(
 			"revision",
 			"*",
-			[ "rev_page" => $pageId ]
+			[ "rev_page" => $pageId ],
+			__METHOD__
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #260

This PR addresses or contains:
- Warning raised: 'SQL query did not specify the caller'

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #260 
