### PR TITLE
Fix #263 class Title not found with mediawiki 1.44

### DIFF
--- a/src/AppFactory.php
+++ b/src/AppFactory.php
@@ -7,7 +7,7 @@ use Onoi\Cache\Cache;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use Title;
+use Mediawiki\Title\Title;
 use User;
 use Wikimedia\Rdbms\Database;
 use WikiPage;

--- a/src/AppFactory.php
+++ b/src/AppFactory.php
@@ -3,11 +3,11 @@
 namespace SESP;
 
 use MediaWiki\MediaWikiServices;
+use Mediawiki\Title\Title;
 use Onoi\Cache\Cache;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use Mediawiki\Title\Title;
 use User;
 use Wikimedia\Rdbms\Database;
 use WikiPage;


### PR DESCRIPTION
This PR is made in reference to: #263

This PR addresses or contains:
- Fix #263

This PR includes:
- [x] Tests (unit/integration)
- [x ] CI build passed

Fixes #263 
