### PR TITLE
Set up baseline for 7.0.0-alpha

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         include:
           - mediawiki_version: '1.43'
-            smw_version: '6.0.1'
+            smw_version: dev-master
             approved_revs_version: 2.1
             php_version: 8.1
             database_type: mysql
@@ -25,7 +25,7 @@ jobs:
             coverage: false
             experimental: false
           - mediawiki_version: '1.43'
-            smw_version: '6.0.1'
+            smw_version: dev-master
             approved_revs_version: 2.1
             php_version: 8.1
             database_type: mysql

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ DB_TYPE?=mysql
 DB_IMAGE?="mariadb:10"
 
 # extensions
-SMW_VERSION?=6.0.1
+SMW_VERSION?=dev-master
 
 # composer
 # Enables "composer update" inside of extension

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ adds some extra [special properties].
 ## Requirements
 
 - PHP 8.1 or later
-- MediaWiki 1.39 or later, tested up to MediaWiki 1.43
-- Semantic MediaWiki 5.0 or later, tested up to SMW 5.0.1
+- MediaWiki 1.43 or later, tested up to MediaWiki 1.45
+- Semantic MediaWiki 7.0 or later
 
 
 ## Installation
@@ -31,7 +31,7 @@ create one and add the following content to it:
 ```
 {
 	"require": {
-		"mediawiki/semantic-extra-special-properties": "~4.0"
+		"mediawiki/semantic-extra-special-properties": "~7.0"
 	}
 }
 ```
@@ -39,7 +39,7 @@ create one and add the following content to it:
 If you already have a "composer.local.json" file, add the following line to the end of the "require"
 section in your file:
 
-    "mediawiki/semantic-extra-special-properties": "~4.0"
+    "mediawiki/semantic-extra-special-properties": "~7.0"
 
 Remember to add a comma to the end of the preceding line in this section.
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,15 @@
 This file contains the RELEASE-NOTES of the **Semantic Extra Special Properties** (a.k.a. SESP) extension.
 
+### 7.0.0-alpha
+
+Released on TBD.
+
+* New minimum required versions:
+  * MediaWiki 1.43
+  * Semantic MediaWiki 7.0
+  * PHP 8.1
+* Major version bumped from 4.x to 7.x to realign with Semantic MediaWiki's major version (5.x and 6.x intentionally skipped).
+
 ### 4.0.0
 
 Released on 2025-03-13.

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
 		"source": "https://github.com/SemanticMediaWiki/SemanticExtraSpecialProperties"
 	},
 	"require": {
-		"php": ">=7.3.0",
+		"php": ">=8.1",
 		"composer/installers": ">=1.0.1"
 	},
 	"require-dev": {
@@ -55,7 +55,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "4.x-dev"
+			"dev-master": "7.x-dev"
 		}
 	},
 	"autoload": {

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "SemanticExtraSpecialProperties",
-	"version": "4.0.0",
+	"version": "7.0.0-alpha",
 	"author": [
 		"Leo Wallentin",
         "James Hong Kong",
@@ -15,7 +15,7 @@
 	"requires": {
 		"MediaWiki": ">= 1.43",
 		"extensions": {
-			"SemanticMediaWiki": ">= 6.0"
+			"SemanticMediaWiki": ">= 7.0"
 		}
 	},
 	"MessagesDirs": {

--- a/src/ExtraPropertyAnnotator.php
+++ b/src/ExtraPropertyAnnotator.php
@@ -6,6 +6,7 @@ use SESP\PropertyAnnotators\DispatchingPropertyAnnotator;
 use SESP\PropertyAnnotators\LocalPropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataModel\SemanticData;
+
 /**
  * @private
  *

--- a/src/ExtraPropertyAnnotator.php
+++ b/src/ExtraPropertyAnnotator.php
@@ -4,9 +4,8 @@ namespace SESP;
 
 use SESP\PropertyAnnotators\DispatchingPropertyAnnotator;
 use SESP\PropertyAnnotators\LocalPropertyAnnotator;
-use SMW\DIProperty;
-use SMW\SemanticData;
-
+use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
 /**
  * @private
  *
@@ -61,7 +60,7 @@ class ExtraPropertyAnnotator {
 				continue;
 			}
 
-			$property = new DIProperty(
+			$property = new Property(
 				$propertyDefinitions->deepGet( $key, 'id' )
 			);
 

--- a/src/PropertyAnnotator.php
+++ b/src/PropertyAnnotator.php
@@ -2,9 +2,8 @@
 
 namespace SESP;
 
-use SMW\DIProperty;
-use SMW\SemanticData;
-
+use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
 /**
  * @license GPL-2.0-or-later
  * @since 2.0
@@ -16,18 +15,18 @@ interface PropertyAnnotator {
 	/**
 	 * @since 2.0
 	 *
-	 * @param DIProperty $property
+	 * @param Property $property
 	 *
 	 * @return bool
 	 */
-	public function isAnnotatorFor( DIProperty $property );
+	public function isAnnotatorFor( Property $property );
 
 	/**
 	 * @since 2.0
 	 *
-	 * @param DIProperty $property
+	 * @param Property $property
 	 * @param SemanticData $semanticData
 	 */
-	public function addAnnotation( DIProperty $property, SemanticData $semanticData );
+	public function addAnnotation( Property $property, SemanticData $semanticData );
 
 }

--- a/src/PropertyAnnotator.php
+++ b/src/PropertyAnnotator.php
@@ -4,6 +4,7 @@ namespace SESP;
 
 use SMW\DataItems\Property;
 use SMW\DataModel\SemanticData;
+
 /**
  * @license GPL-2.0-or-later
  * @since 2.0

--- a/src/PropertyAnnotators/ApprovedByPropertyAnnotator.php
+++ b/src/PropertyAnnotators/ApprovedByPropertyAnnotator.php
@@ -7,10 +7,9 @@ use MediaWiki\Title\Title;
 use MediaWiki\User\User;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DIProperty;
-use SMW\DIWikiPage;
-use SMW\SemanticData;
-
+use SMW\DataItems\Property;
+use SMW\DataItems\WikiPage;
+use SMW\DataModel\SemanticData;
 /**
  * @private
  * @ingroup SESP
@@ -53,14 +52,14 @@ class ApprovedByPropertyAnnotator implements PropertyAnnotator {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function isAnnotatorFor( DIProperty $property ) {
+	public function isAnnotatorFor( Property $property ) {
 		return $property->getKey() === self::PROP_ID;
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public function addAnnotation( DIProperty $property, SemanticData $semanticData ) {
+	public function addAnnotation( Property $property, SemanticData $semanticData ) {
 		if ( $this->approvedBy === null && class_exists( 'ApprovedRevs' ) ) {
 			$title = $semanticData->getSubject()->getTitle();
 			if ( ApprovedRevs::pageIsApprovable( $title ) ) {
@@ -82,7 +81,7 @@ class ApprovedByPropertyAnnotator implements PropertyAnnotator {
 			$userPage = $this->approvedBy->getUserPage();
 
 			if ( $userPage instanceof Title ) {
-				return DIWikiPage::newFromTitle( $userPage );
+				return WikiPage::newFromTitle( $userPage );
 			}
 		}
 	}

--- a/src/PropertyAnnotators/ApprovedByPropertyAnnotator.php
+++ b/src/PropertyAnnotators/ApprovedByPropertyAnnotator.php
@@ -10,6 +10,7 @@ use SESP\PropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
+
 /**
  * @private
  * @ingroup SESP

--- a/src/PropertyAnnotators/ApprovedDatePropertyAnnotator.php
+++ b/src/PropertyAnnotators/ApprovedDatePropertyAnnotator.php
@@ -5,10 +5,9 @@ namespace SESP\PropertyAnnotators;
 use MWTimestamp;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DIProperty;
-use SMW\SemanticData;
-use SMWDITime as DITime;
-
+use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+use SMW\DataItems\Time;
 /**
  * @private
  * @ingroup SESP
@@ -51,14 +50,14 @@ class ApprovedDatePropertyAnnotator implements PropertyAnnotator {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function isAnnotatorFor( DIProperty $property ) {
+	public function isAnnotatorFor( Property $property ) {
 		return $property->getKey() === self::PROP_ID;
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public function addAnnotation( DIProperty $property, SemanticData $semanticData ) {
+	public function addAnnotation( Property $property, SemanticData $semanticData ) {
 		if ( $this->approvedDate === null && class_exists( 'ApprovedRevs' ) ) {
 			// ApprovedRevs does not provide a function to get the approval date,
 			// so fetch it here from the ApprovedRevs table
@@ -87,8 +86,8 @@ class ApprovedDatePropertyAnnotator implements PropertyAnnotator {
 	private function getDataItem() {
 		if ( $this->approvedDate ) {
 			$date = $this->approvedDate;
-			return new DITime(
-				DITime::CM_GREGORIAN,
+			return new Time(
+				Time::CM_GREGORIAN,
 				$date->format( 'Y' ),
 				$date->format( 'm' ),
 				$date->format( 'd' ),

--- a/src/PropertyAnnotators/ApprovedDatePropertyAnnotator.php
+++ b/src/PropertyAnnotators/ApprovedDatePropertyAnnotator.php
@@ -6,8 +6,9 @@ use MWTimestamp;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
 use SMW\DataItems\Property;
-use SMW\DataModel\SemanticData;
 use SMW\DataItems\Time;
+use SMW\DataModel\SemanticData;
+
 /**
  * @private
  * @ingroup SESP

--- a/src/PropertyAnnotators/ApprovedRevPropertyAnnotator.php
+++ b/src/PropertyAnnotators/ApprovedRevPropertyAnnotator.php
@@ -5,9 +5,10 @@ namespace SESP\PropertyAnnotators;
 use ApprovedRevs;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
+use SMW\DataItems\Number;
 use SMW\DataItems\Property;
 use SMW\DataModel\SemanticData;
-use SMW\DataItems\Number;
+
 /**
  * @private
  * @ingroup SESP
@@ -64,7 +65,7 @@ class ApprovedRevPropertyAnnotator implements PropertyAnnotator {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function addAnnotation( Property $property, SemanticData $semanticData	) {
+	public function addAnnotation( Property $property, SemanticData $semanticData ) {
 		if ( $this->approvedRev === null && class_exists( 'ApprovedRevs' ) ) {
 			$this->approvedRev = ApprovedRevs::getApprovedRevID(
 				$semanticData->getSubject()->getTitle()

--- a/src/PropertyAnnotators/ApprovedRevPropertyAnnotator.php
+++ b/src/PropertyAnnotators/ApprovedRevPropertyAnnotator.php
@@ -5,10 +5,9 @@ namespace SESP\PropertyAnnotators;
 use ApprovedRevs;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DIProperty;
-use SMW\SemanticData;
-use SMWDINumber as DINumber;
-
+use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+use SMW\DataItems\Number;
 /**
  * @private
  * @ingroup SESP
@@ -51,7 +50,7 @@ class ApprovedRevPropertyAnnotator implements PropertyAnnotator {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function isAnnotatorFor( DIProperty $property ) {
+	public function isAnnotatorFor( Property $property ) {
 		return $property->getKey() === self::PROP_ID;
 	}
 
@@ -59,13 +58,13 @@ class ApprovedRevPropertyAnnotator implements PropertyAnnotator {
 	 * get data item
 	 */
 	public function getDataItem() {
-		return new DINumber( $this->approvedRev );
+		return new Number( $this->approvedRev );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public function addAnnotation( DIProperty $property, SemanticData $semanticData	) {
+	public function addAnnotation( Property $property, SemanticData $semanticData	) {
 		if ( $this->approvedRev === null && class_exists( 'ApprovedRevs' ) ) {
 			$this->approvedRev = ApprovedRevs::getApprovedRevID(
 				$semanticData->getSubject()->getTitle()

--- a/src/PropertyAnnotators/ApprovedStatusPropertyAnnotator.php
+++ b/src/PropertyAnnotators/ApprovedStatusPropertyAnnotator.php
@@ -6,9 +6,9 @@ use ApprovedRevs;
 use IDBAccessObject;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
+use SMW\DataItems\Blob as DIString;
 use SMW\DataItems\Property;
 use SMW\DataModel\SemanticData;
-use SMW\DataItems\Blob as DIString;
 
 /**
  * @private

--- a/src/PropertyAnnotators/ApprovedStatusPropertyAnnotator.php
+++ b/src/PropertyAnnotators/ApprovedStatusPropertyAnnotator.php
@@ -8,7 +8,7 @@ use SESP\AppFactory;
 use SESP\PropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataModel\SemanticData;
-use Blob as DIString;
+use SMW\DataItems\Blob as DIString;
 
 /**
  * @private

--- a/src/PropertyAnnotators/ApprovedStatusPropertyAnnotator.php
+++ b/src/PropertyAnnotators/ApprovedStatusPropertyAnnotator.php
@@ -6,9 +6,9 @@ use ApprovedRevs;
 use IDBAccessObject;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DIProperty;
-use SMW\SemanticData;
-use SMWDIBlob as DIString;
+use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+use Blob as DIString;
 
 /**
  * @private
@@ -52,14 +52,14 @@ class ApprovedStatusPropertyAnnotator implements PropertyAnnotator {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function isAnnotatorFor( DIProperty $property ) {
+	public function isAnnotatorFor( Property $property ) {
 		return $property->getKey() === self::PROP_ID;
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public function addAnnotation( DIProperty $property, SemanticData $semanticData ) {
+	public function addAnnotation( Property $property, SemanticData $semanticData ) {
 		if ( $this->approvedStatus === null && class_exists( 'ApprovedRevs' ) ) {
 			$title = $semanticData->getSubject()->getTitle();
 			if ( ApprovedRevs::pageIsApprovable( $title ) ) {

--- a/src/PropertyAnnotators/CreatorPropertyAnnotator.php
+++ b/src/PropertyAnnotators/CreatorPropertyAnnotator.php
@@ -7,10 +7,11 @@ use MediaWiki\Title\Title;
 use MediaWiki\User\User;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
+use SMW\DataItems\DataItem;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
-use SMW\DataItems\DataItem;
+
 /**
  * @private
  * @ingroup SESP

--- a/src/PropertyAnnotators/CreatorPropertyAnnotator.php
+++ b/src/PropertyAnnotators/CreatorPropertyAnnotator.php
@@ -7,11 +7,10 @@ use MediaWiki\Title\Title;
 use MediaWiki\User\User;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DIProperty;
-use SMW\DIWikiPage;
-use SMW\SemanticData;
-use SMWDataItem as DataItem;
-
+use SMW\DataItems\Property;
+use SMW\DataItems\WikiPage;
+use SMW\DataModel\SemanticData;
+use SMW\DataItems\DataItem;
 /**
  * @private
  * @ingroup SESP
@@ -47,7 +46,7 @@ class CreatorPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function isAnnotatorFor( DIProperty $property ) {
+	public function isAnnotatorFor( Property $property ) {
 		return $property->getKey() === self::PROP_ID;
 	}
 
@@ -56,7 +55,7 @@ class CreatorPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function addAnnotation( DIProperty $property, SemanticData $semanticData ) {
+	public function addAnnotation( Property $property, SemanticData $semanticData ) {
 		$page = $this->appFactory->newWikiPage( $semanticData->getSubject()->getTitle() );
 		$dataItem = null;
 
@@ -66,7 +65,7 @@ class CreatorPropertyAnnotator implements PropertyAnnotator {
 				$creator = MediaWikiServices::getInstance()->getUserFactory()->newFromUserIdentity( $creator );
 			}
 			if ( ( $userPage = $creator->getUserPage() ) instanceof Title ) {
-				$dataItem = DIWikiPage::newFromTitle( $userPage );
+				$dataItem = WikiPage::newFromTitle( $userPage );
 			}
 		}
 

--- a/src/PropertyAnnotators/DispatchingPropertyAnnotator.php
+++ b/src/PropertyAnnotators/DispatchingPropertyAnnotator.php
@@ -4,9 +4,8 @@ namespace SESP\PropertyAnnotators;
 
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DIProperty;
-use SMW\SemanticData;
-
+use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
 /**
  * @private
  * @ingroup SESP
@@ -47,7 +46,7 @@ class DispatchingPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function isAnnotatorFor( DIProperty $property ) {
+	public function isAnnotatorFor( Property $property ) {
 		return true;
 	}
 
@@ -66,18 +65,18 @@ class DispatchingPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function addAnnotation( DIProperty $property, SemanticData $semanticData ) {
+	public function addAnnotation( Property $property, SemanticData $semanticData ) {
 		$this->findPropertyAnnotator( $property )->addAnnotation( $property, $semanticData );
 	}
 
 	/**
 	 * @since 2.0
 	 *
-	 * @param DIProperty $property
+	 * @param Property $property
 	 *
 	 * @return PropertyAnnotator
 	 */
-	public function findPropertyAnnotator( DIProperty $property ) {
+	public function findPropertyAnnotator( Property $property ) {
 		$key = $property->getKey();
 
 		if ( $this->propertyAnnotators === [] ) {

--- a/src/PropertyAnnotators/DispatchingPropertyAnnotator.php
+++ b/src/PropertyAnnotators/DispatchingPropertyAnnotator.php
@@ -6,6 +6,7 @@ use SESP\AppFactory;
 use SESP\PropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataModel\SemanticData;
+
 /**
  * @private
  * @ingroup SESP

--- a/src/PropertyAnnotators/ExifPropertyAnnotator.php
+++ b/src/PropertyAnnotators/ExifPropertyAnnotator.php
@@ -5,15 +5,16 @@ namespace SESP\PropertyAnnotators;
 use FormatMetadata;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DataModel\ContainerSemanticData;
-use SMW\DataItems\Property;
-use SMW\DataItems\WikiPage;
-use SMW\DataModel\SemanticData;
-use SMW\DataItems\DataItem;
 use SMW\DataItems\Blob;
 use SMW\DataItems\Container;
+use SMW\DataItems\DataItem;
 use SMW\DataItems\Number;
+use SMW\DataItems\Property;
 use SMW\DataItems\Time;
+use SMW\DataItems\WikiPage;
+use SMW\DataModel\ContainerSemanticData;
+use SMW\DataModel\SemanticData;
+
 /**
  * @private
  * @ingroup SESP

--- a/src/PropertyAnnotators/ExifPropertyAnnotator.php
+++ b/src/PropertyAnnotators/ExifPropertyAnnotator.php
@@ -6,15 +6,14 @@ use FormatMetadata;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
 use SMW\DataModel\ContainerSemanticData;
-use SMW\DIProperty;
-use SMW\DIWikiPage;
-use SMW\SemanticData;
-use SMWDataItem as DataItem;
-use SMWDIBlob as DIBlob;
-use SMWDIContainer as DIContainer;
-use SMWDINumber as DINumber;
-use SMWDITime as DITime;
-
+use SMW\DataItems\Property;
+use SMW\DataItems\WikiPage;
+use SMW\DataModel\SemanticData;
+use SMW\DataItems\DataItem;
+use SMW\DataItems\Blob;
+use SMW\DataItems\Container;
+use SMW\DataItems\Number;
+use SMW\DataItems\Time;
 /**
  * @private
  * @ingroup SESP
@@ -54,7 +53,7 @@ class ExifPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function isAnnotatorFor( DIProperty $property ) {
+	public function isAnnotatorFor( Property $property ) {
 		return $property->getKey() === self::PROP_ID;
 	}
 
@@ -63,7 +62,7 @@ class ExifPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function addAnnotation( DIProperty $property, SemanticData $semanticData ) {
+	public function addAnnotation( Property $property, SemanticData $semanticData ) {
 		$subject = $semanticData->getSubject();
 		$title = $subject->getTitle();
 
@@ -109,7 +108,7 @@ class ExifPropertyAnnotator implements PropertyAnnotator {
 	/**
 	 * @since 2.0
 	 *
-	 * @param DIWikiPage $subject
+	 * @param WikiPage $subject
 	 * @param array $rawExif The raw EXIF data to be added.
 	 */
 	protected function getDataItemFromExifData( $subject, $rawExif ) {
@@ -123,11 +122,11 @@ class ExifPropertyAnnotator implements PropertyAnnotator {
 			return;
 		}
 
-		return new DIContainer( $containerSemanticData );
+		return new Container( $containerSemanticData );
 	}
 
 	private function newContainerSemanticData( $subject ) {
-		$subject = new DIWikiPage(
+		$subject = new WikiPage(
 			$subject->getDBkey(),
 			$subject->getNamespace(),
 			$subject->getInterwiki(),
@@ -146,7 +145,7 @@ class ExifPropertyAnnotator implements PropertyAnnotator {
 			$dataItem = $this->createDataItemFromExif( $id, $key, $value, $rawExif, $exifDefinitions );
 
 			if ( $dataItem instanceof DataItem ) {
-				$containerSemanticData->addPropertyObjectValue( new DIProperty( $id ), $dataItem );
+				$containerSemanticData->addPropertyObjectValue( new Property( $id ), $dataItem );
 			}
 		}
 	}
@@ -164,10 +163,10 @@ class ExifPropertyAnnotator implements PropertyAnnotator {
 
 		switch ( $type ) {
 			case '_num':
-				$dataItem = is_numeric( $rawExif[$key] ) ? new DINumber( $rawExif[$key] ) : null;
+				$dataItem = is_numeric( $rawExif[$key] ) ? new Number( $rawExif[$key] ) : null;
 				break;
 			case '_txt':
-				$dataItem = new DIBlob( $value );
+				$dataItem = new Blob( $value );
 				break;
 			case '_dat':
 				$dataItem = $this->makeDataItemTime( $rawExif[$key] );
@@ -184,8 +183,8 @@ class ExifPropertyAnnotator implements PropertyAnnotator {
 		}
 
 		if ( $datetime ) {
-			return new DITime(
-				DITime::CM_GREGORIAN,
+			return new Time(
+				Time::CM_GREGORIAN,
 				$datetime->format( 'Y' ),
 				$datetime->format( 'n' ),
 				$datetime->format( 'j' ),

--- a/src/PropertyAnnotators/LinksToPropertyAnnotator.php
+++ b/src/PropertyAnnotators/LinksToPropertyAnnotator.php
@@ -9,6 +9,7 @@ use SESP\PropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
+
 /**
  * @private
  * @ingroup SESP

--- a/src/PropertyAnnotators/LinksToPropertyAnnotator.php
+++ b/src/PropertyAnnotators/LinksToPropertyAnnotator.php
@@ -6,10 +6,9 @@ use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DIProperty;
-use SMW\DIWikiPage;
-use SMW\SemanticData;
-
+use SMW\DataItems\Property;
+use SMW\DataItems\WikiPage;
+use SMW\DataModel\SemanticData;
 /**
  * @private
  * @ingroup SESP
@@ -52,7 +51,7 @@ class LinksToPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function isAnnotatorFor( DIProperty $property ) {
+	public function isAnnotatorFor( Property $property ) {
 		return $property->getKey() === self::PROP_ID;
 	}
 
@@ -61,7 +60,7 @@ class LinksToPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function addAnnotation( DIProperty $property, SemanticData $semanticData ) {
+	public function addAnnotation( Property $property, SemanticData $semanticData ) {
 		$page = $semanticData->getSubject()->getTitle();
 
 		if (
@@ -95,7 +94,7 @@ class LinksToPropertyAnnotator implements PropertyAnnotator {
 		foreach ( $res as $row ) {
 			$title = Title::newFromText( $row->sel_title, $row->sel_ns );
 			if ( $title !== null && $title->exists() ) {
-				$semanticData->addPropertyObjectValue( $property, DIWikiPage::newFromTitle( $title ) );
+				$semanticData->addPropertyObjectValue( $property, WikiPage::newFromTitle( $title ) );
 			}
 		}
 	}

--- a/src/PropertyAnnotators/LocalPropertyAnnotator.php
+++ b/src/PropertyAnnotators/LocalPropertyAnnotator.php
@@ -4,9 +4,10 @@ namespace SESP\PropertyAnnotators;
 
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
+use SMW\DataItems\DataItem;
 use SMW\DataItems\Property;
 use SMW\DataModel\SemanticData;
-use SMW\DataItems\DataItem;
+
 /**
  * @private
  * @ingroup SESP

--- a/src/PropertyAnnotators/LocalPropertyAnnotator.php
+++ b/src/PropertyAnnotators/LocalPropertyAnnotator.php
@@ -4,10 +4,9 @@ namespace SESP\PropertyAnnotators;
 
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DIProperty;
-use SMW\SemanticData;
-use SMWDataItem as DataItem;
-
+use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+use SMW\DataItems\DataItem;
 /**
  * @private
  * @ingroup SESP
@@ -38,7 +37,7 @@ class LocalPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function isAnnotatorFor( DIProperty $property ) {
+	public function isAnnotatorFor( Property $property ) {
 		return true;
 	}
 
@@ -47,7 +46,7 @@ class LocalPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function addAnnotation( DIProperty $property, SemanticData $semanticData ) {
+	public function addAnnotation( Property $property, SemanticData $semanticData ) {
 		$time = microtime( true );
 
 		$localDefs = $this->appFactory->getOption( 'sespgLocalDefinitions', [] );

--- a/src/PropertyAnnotators/NamespaceNamePropertyAnnotator.php
+++ b/src/PropertyAnnotators/NamespaceNamePropertyAnnotator.php
@@ -6,10 +6,9 @@ use MediaWiki\MediaWikiServices;
 use RequestContext;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DIProperty;
-use SMW\SemanticData;
-use SMWDIBlob;
-
+use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+use SMW\DataItems\Blob;
 /**
  * @private
  * @ingroup SESP
@@ -38,21 +37,21 @@ class NamespaceNamePropertyAnnotator implements PropertyAnnotator {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function isAnnotatorFor( DIProperty $property ) {
+	public function isAnnotatorFor( Property $property ) {
 		return $property->getKey() === self::PROP_ID;
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public function addAnnotation( DIProperty $property, SemanticData $semanticData ) {
+	public function addAnnotation( Property $property, SemanticData $semanticData ) {
 		$nsInfo = MediaWikiServices::getInstance()->getNamespaceInfo();
 		$namespaceName = $nsInfo->getCanonicalName( $semanticData->getSubject()->getTitle()->getNamespace() );
 		if ( $namespaceName !== false ) {
 			if ( $namespaceName === '' ) {
 				$namespaceName = RequestContext::getMain()->msg( 'blanknamespace' )->text();
 			}
-			$dataItem = new SMWDIBlob( $namespaceName );
+			$dataItem = new Blob( $namespaceName );
 			$semanticData->addPropertyObjectValue( $property, $dataItem );
 		}
 	}

--- a/src/PropertyAnnotators/NamespaceNamePropertyAnnotator.php
+++ b/src/PropertyAnnotators/NamespaceNamePropertyAnnotator.php
@@ -6,9 +6,10 @@ use MediaWiki\MediaWikiServices;
 use RequestContext;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
+use SMW\DataItems\Blob;
 use SMW\DataItems\Property;
 use SMW\DataModel\SemanticData;
-use SMW\DataItems\Blob;
+
 /**
  * @private
  * @ingroup SESP

--- a/src/PropertyAnnotators/NamespacePropertyAnnotator.php
+++ b/src/PropertyAnnotators/NamespacePropertyAnnotator.php
@@ -4,10 +4,9 @@ namespace SESP\PropertyAnnotators;
 
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DIProperty;
-use SMW\SemanticData;
-use SMWDINumber;
-
+use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+use SMW\DataItems\Number;
 /**
  * @private
  * @ingroup SESP
@@ -36,15 +35,15 @@ class NamespacePropertyAnnotator implements PropertyAnnotator {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function isAnnotatorFor( DIProperty $property ) {
+	public function isAnnotatorFor( Property $property ) {
 		return $property->getKey() === self::PROP_ID;
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public function addAnnotation( DIProperty $property, SemanticData $semanticData ) {
-		$dataItem = new SMWDINumber( $semanticData->getSubject()->getTitle()->getNamespace() );
+	public function addAnnotation( Property $property, SemanticData $semanticData ) {
+		$dataItem = new Number( $semanticData->getSubject()->getTitle()->getNamespace() );
 		$semanticData->addPropertyObjectValue( $property, $dataItem );
 	}
 }

--- a/src/PropertyAnnotators/NamespacePropertyAnnotator.php
+++ b/src/PropertyAnnotators/NamespacePropertyAnnotator.php
@@ -4,9 +4,10 @@ namespace SESP\PropertyAnnotators;
 
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
+use SMW\DataItems\Number;
 use SMW\DataItems\Property;
 use SMW\DataModel\SemanticData;
-use SMW\DataItems\Number;
+
 /**
  * @private
  * @ingroup SESP

--- a/src/PropertyAnnotators/NullPropertyAnnotator.php
+++ b/src/PropertyAnnotators/NullPropertyAnnotator.php
@@ -3,9 +3,8 @@
 namespace SESP\PropertyAnnotators;
 
 use SESP\PropertyAnnotator;
-use SMW\DIProperty;
-use SMW\SemanticData;
-
+use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
 /**
  * @private
  * @ingroup SESP
@@ -22,7 +21,7 @@ class NullPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function isAnnotatorFor( DIProperty $property ) {
+	public function isAnnotatorFor( Property $property ) {
 		return true;
 	}
 
@@ -31,7 +30,7 @@ class NullPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function addAnnotation( DIProperty $property, SemanticData $semanticData ) {
+	public function addAnnotation( Property $property, SemanticData $semanticData ) {
 	}
 
 }

--- a/src/PropertyAnnotators/NullPropertyAnnotator.php
+++ b/src/PropertyAnnotators/NullPropertyAnnotator.php
@@ -5,6 +5,7 @@ namespace SESP\PropertyAnnotators;
 use SESP\PropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataModel\SemanticData;
+
 /**
  * @private
  * @ingroup SESP

--- a/src/PropertyAnnotators/PageContributorsPropertyAnnotator.php
+++ b/src/PropertyAnnotators/PageContributorsPropertyAnnotator.php
@@ -9,6 +9,7 @@ use SESP\PropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
+
 /**
  * @private
  * @ingroup SESP

--- a/src/PropertyAnnotators/PageContributorsPropertyAnnotator.php
+++ b/src/PropertyAnnotators/PageContributorsPropertyAnnotator.php
@@ -6,10 +6,9 @@ use MediaWiki\MediaWikiServices;
 use MediaWiki\Permissions\PermissionManager;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DIProperty;
-use SMW\DIWikiPage;
-use SMW\SemanticData;
-
+use SMW\DataItems\Property;
+use SMW\DataItems\WikiPage;
+use SMW\DataModel\SemanticData;
 /**
  * @private
  * @ingroup SESP
@@ -51,7 +50,7 @@ class PageContributorsPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function isAnnotatorFor( DIProperty $property ) {
+	public function isAnnotatorFor( Property $property ) {
 		return $property->getKey() === self::PROP_ID;
 	}
 
@@ -60,7 +59,7 @@ class PageContributorsPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function addAnnotation( DIProperty $property, SemanticData $semanticData ) {
+	public function addAnnotation( Property $property, SemanticData $semanticData ) {
 		$title = $semanticData->getSubject()->getTitle();
 		$page = $this->appFactory->newWikiPage( $title );
 
@@ -78,7 +77,7 @@ class PageContributorsPropertyAnnotator implements PropertyAnnotator {
 			if ( $this->isNotAnonymous( $user ) ) {
 				$semanticData->addPropertyObjectValue(
 					$property,
-					DIWikiPage::newFromTitle( $user->getUserPage() )
+					WikiPage::newFromTitle( $user->getUserPage() )
 				);
 			}
 

--- a/src/PropertyAnnotators/PageIDPropertyAnnotator.php
+++ b/src/PropertyAnnotators/PageIDPropertyAnnotator.php
@@ -4,11 +4,10 @@ namespace SESP\PropertyAnnotators;
 
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DIProperty;
-use SMW\SemanticData;
-use SMWDataItem as DataItem;
-use SMWDINumber as DINumber;
-
+use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+use SMW\DataItems\DataItem;
+use SMW\DataItems\Number;
 /**
  * @private
  * @ingroup SESP
@@ -44,7 +43,7 @@ class PageIDPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function isAnnotatorFor( DIProperty $property ) {
+	public function isAnnotatorFor( Property $property ) {
 		return $property->getKey() === self::PROP_ID;
 	}
 
@@ -53,7 +52,7 @@ class PageIDPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function addAnnotation( DIProperty $property, SemanticData $semanticData ) {
+	public function addAnnotation( Property $property, SemanticData $semanticData ) {
 		$page = $this->appFactory->newWikiPage(
 			$semanticData->getSubject()->getTitle()
 		);
@@ -62,7 +61,7 @@ class PageIDPropertyAnnotator implements PropertyAnnotator {
 		$dataItem = null;
 
 		if ( is_int( $pageID ) && $pageID > 0 ) {
-			$dataItem = new DINumber( $pageID );
+			$dataItem = new Number( $pageID );
 		}
 
 		if ( $dataItem instanceof DataItem ) {

--- a/src/PropertyAnnotators/PageIDPropertyAnnotator.php
+++ b/src/PropertyAnnotators/PageIDPropertyAnnotator.php
@@ -4,10 +4,11 @@ namespace SESP\PropertyAnnotators;
 
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DataItems\Property;
-use SMW\DataModel\SemanticData;
 use SMW\DataItems\DataItem;
 use SMW\DataItems\Number;
+use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+
 /**
  * @private
  * @ingroup SESP

--- a/src/PropertyAnnotators/PageImagesPropertyAnnotator.php
+++ b/src/PropertyAnnotators/PageImagesPropertyAnnotator.php
@@ -6,10 +6,9 @@ use File;
 use MediaWiki\Title\Title;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DIProperty;
-use SMW\DIWikiPage;
-use SMW\SemanticData;
-
+use SMW\DataItems\Property;
+use SMW\DataItems\WikiPage;
+use SMW\DataModel\SemanticData;
 class PageImagesPropertyAnnotator implements PropertyAnnotator {
 
 	/**
@@ -36,7 +35,7 @@ class PageImagesPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function isAnnotatorFor( DIProperty $property ) {
+	public function isAnnotatorFor( Property $property ) {
 		return $property->getKey() === self::PROP_ID;
 	}
 
@@ -45,12 +44,12 @@ class PageImagesPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function addAnnotation( DIProperty $property, SemanticData $semanticData ) {
+	public function addAnnotation( Property $property, SemanticData $semanticData ) {
 		$Title = $semanticData->getSubject()->getTitle();
 		$pageImageTitle = $this->getPageImageTitle( $Title );
 
 		if ( $pageImageTitle ) {
-			$semanticData->addPropertyObjectValue( $property, DIWikiPage::newFromTitle( $pageImageTitle ) );
+			$semanticData->addPropertyObjectValue( $property, WikiPage::newFromTitle( $pageImageTitle ) );
 		}
 	}
 

--- a/src/PropertyAnnotators/PageImagesPropertyAnnotator.php
+++ b/src/PropertyAnnotators/PageImagesPropertyAnnotator.php
@@ -9,6 +9,7 @@ use SESP\PropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
+
 class PageImagesPropertyAnnotator implements PropertyAnnotator {
 
 	/**

--- a/src/PropertyAnnotators/PageLengthPropertyAnnotator.php
+++ b/src/PropertyAnnotators/PageLengthPropertyAnnotator.php
@@ -4,10 +4,11 @@ namespace SESP\PropertyAnnotators;
 
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DataItems\Property;
-use SMW\DataModel\SemanticData;
 use SMW\DataItems\DataItem;
 use SMW\DataItems\Number;
+use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+
 /**
  * @private
  * @ingroup SESP

--- a/src/PropertyAnnotators/PageLengthPropertyAnnotator.php
+++ b/src/PropertyAnnotators/PageLengthPropertyAnnotator.php
@@ -4,11 +4,10 @@ namespace SESP\PropertyAnnotators;
 
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DIProperty;
-use SMW\SemanticData;
-use SMWDataItem as DataItem;
-use SMWDINumber as DINumber;
-
+use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+use SMW\DataItems\DataItem;
+use SMW\DataItems\Number;
 /**
  * @private
  * @ingroup SESP
@@ -44,7 +43,7 @@ class PageLengthPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function isAnnotatorFor( DIProperty $property ) {
+	public function isAnnotatorFor( Property $property ) {
 		return $property->getKey() === self::PROP_ID;
 	}
 
@@ -53,14 +52,14 @@ class PageLengthPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function addAnnotation( DIProperty $property, SemanticData $semanticData ) {
+	public function addAnnotation( Property $property, SemanticData $semanticData ) {
 		$title = $semanticData->getSubject()->getTitle();
 
 		$length = $title->getLength();
 		$dataItem = null;
 
 		if ( is_int( $length ) && $length > 0 ) {
-			$dataItem = new DINumber( $length );
+			$dataItem = new Number( $length );
 		}
 
 		if ( $dataItem instanceof DataItem ) {

--- a/src/PropertyAnnotators/PageNumRevisionPropertyAnnotator.php
+++ b/src/PropertyAnnotators/PageNumRevisionPropertyAnnotator.php
@@ -4,11 +4,10 @@ namespace SESP\PropertyAnnotators;
 
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DIProperty;
-use SMW\SemanticData;
-use SMWDataItem as DataItem;
-use SMWDINumber as DINumber;
-
+use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+use SMW\DataItems\DataItem;
+use SMW\DataItems\Number;
 /**
  * @private
  * @ingroup SESP
@@ -44,7 +43,7 @@ class PageNumRevisionPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function isAnnotatorFor( DIProperty $property ) {
+	public function isAnnotatorFor( Property $property ) {
 		return $property->getKey() === self::PROP_ID;
 	}
 
@@ -53,7 +52,7 @@ class PageNumRevisionPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function addAnnotation( DIProperty $property, SemanticData $semanticData ) {
+	public function addAnnotation( Property $property, SemanticData $semanticData ) {
 		$title = $semanticData->getSubject()->getTitle();
 
 		$numRevisions = $this->getPageRevisions(
@@ -63,7 +62,7 @@ class PageNumRevisionPropertyAnnotator implements PropertyAnnotator {
 		$dataItem = null;
 
 		if ( $title->exists() && $numRevisions > 0 ) {
-			$dataItem = new DINumber( $numRevisions );
+			$dataItem = new Number( $numRevisions );
 		}
 
 		if ( $dataItem instanceof DataItem ) {

--- a/src/PropertyAnnotators/PageNumRevisionPropertyAnnotator.php
+++ b/src/PropertyAnnotators/PageNumRevisionPropertyAnnotator.php
@@ -4,10 +4,11 @@ namespace SESP\PropertyAnnotators;
 
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DataItems\Property;
-use SMW\DataModel\SemanticData;
 use SMW\DataItems\DataItem;
 use SMW\DataItems\Number;
+use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+
 /**
  * @private
  * @ingroup SESP

--- a/src/PropertyAnnotators/PageViewsPropertyAnnotator.php
+++ b/src/PropertyAnnotators/PageViewsPropertyAnnotator.php
@@ -4,10 +4,9 @@ namespace SESP\PropertyAnnotators;
 
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DIProperty;
-use SMW\SemanticData;
-use SMWDINumber as DINumber;
-
+use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+use SMW\DataItems\Number;
 /**
  * @private
  * @ingroup SESP
@@ -43,7 +42,7 @@ class PageViewsPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function isAnnotatorFor( DIProperty $property ) {
+	public function isAnnotatorFor( Property $property ) {
 		return $property->getKey() === self::PROP_ID;
 	}
 
@@ -52,7 +51,7 @@ class PageViewsPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function addAnnotation( DIProperty $property, SemanticData $semanticData ) {
+	public function addAnnotation( Property $property, SemanticData $semanticData ) {
 		if ( $this->appFactory->getOption( 'wgDisableCounters' ) ) {
 			return null;
 		}
@@ -61,7 +60,7 @@ class PageViewsPropertyAnnotator implements PropertyAnnotator {
 		$count = $this->getPageViewCount( $page );
 
 		if ( is_numeric( $count ) ) {
-			$semanticData->addPropertyObjectValue( $property, new DINumber( $count ) );
+			$semanticData->addPropertyObjectValue( $property, new Number( $count ) );
 		}
 	}
 

--- a/src/PropertyAnnotators/PageViewsPropertyAnnotator.php
+++ b/src/PropertyAnnotators/PageViewsPropertyAnnotator.php
@@ -4,9 +4,10 @@ namespace SESP\PropertyAnnotators;
 
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
+use SMW\DataItems\Number;
 use SMW\DataItems\Property;
 use SMW\DataModel\SemanticData;
-use SMW\DataItems\Number;
+
 /**
  * @private
  * @ingroup SESP

--- a/src/PropertyAnnotators/RevisionIDPropertyAnnotator.php
+++ b/src/PropertyAnnotators/RevisionIDPropertyAnnotator.php
@@ -4,11 +4,10 @@ namespace SESP\PropertyAnnotators;
 
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DIProperty;
-use SMW\SemanticData;
-use SMWDataItem as DataItem;
-use SMWDINumber as DINumber;
-
+use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+use SMW\DataItems\DataItem;
+use SMW\DataItems\Number;
 /**
  * @private
  * @ingroup SESP
@@ -44,7 +43,7 @@ class RevisionIDPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function isAnnotatorFor( DIProperty $property ) {
+	public function isAnnotatorFor( Property $property ) {
 		return $property->getKey() === self::PROP_ID;
 	}
 
@@ -53,7 +52,7 @@ class RevisionIDPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function addAnnotation( DIProperty $property, SemanticData $semanticData ) {
+	public function addAnnotation( Property $property, SemanticData $semanticData ) {
 		$page = $this->appFactory->newWikiPage(
 			$semanticData->getSubject()->getTitle()
 		);
@@ -62,7 +61,7 @@ class RevisionIDPropertyAnnotator implements PropertyAnnotator {
 		$dataItem = null;
 
 		if ( is_int( $revID ) && $revID > 0 ) {
-			$dataItem = new DINumber( $revID );
+			$dataItem = new Number( $revID );
 		}
 
 		if ( $dataItem instanceof DataItem ) {

--- a/src/PropertyAnnotators/RevisionIDPropertyAnnotator.php
+++ b/src/PropertyAnnotators/RevisionIDPropertyAnnotator.php
@@ -4,10 +4,11 @@ namespace SESP\PropertyAnnotators;
 
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DataItems\Property;
-use SMW\DataModel\SemanticData;
 use SMW\DataItems\DataItem;
 use SMW\DataItems\Number;
+use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+
 /**
  * @private
  * @ingroup SESP

--- a/src/PropertyAnnotators/ShortUrlPropertyAnnotator.php
+++ b/src/PropertyAnnotators/ShortUrlPropertyAnnotator.php
@@ -6,10 +6,11 @@ use MediaWiki\Title\Title;
 use RuntimeException;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DataItems\Property;
-use SMW\DataModel\SemanticData;
 use SMW\DataItems\DataItem;
+use SMW\DataItems\Property;
 use SMW\DataItems\Uri;
+use SMW\DataModel\SemanticData;
+
 /**
  * @private
  * @ingroup SESP

--- a/src/PropertyAnnotators/ShortUrlPropertyAnnotator.php
+++ b/src/PropertyAnnotators/ShortUrlPropertyAnnotator.php
@@ -6,11 +6,10 @@ use MediaWiki\Title\Title;
 use RuntimeException;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DIProperty;
-use SMW\SemanticData;
-use SMWDataItem as DataItem;
-use SMWDIUri as DIUri;
-
+use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+use SMW\DataItems\DataItem;
+use SMW\DataItems\Uri;
 /**
  * @private
  * @ingroup SESP
@@ -47,7 +46,7 @@ class ShortUrlPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function isAnnotatorFor( DIProperty $property ) {
+	public function isAnnotatorFor( Property $property ) {
 		return $property->getKey() === self::PROP_ID;
 	}
 
@@ -56,7 +55,7 @@ class ShortUrlPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function addAnnotation( DIProperty $property, SemanticData $semanticData ) {
+	public function addAnnotation( Property $property, SemanticData $semanticData ) {
 		if ( !$this->hasShortUrlUtils() ) {
 			throw new RuntimeException( 'Class ShortUrlUtils is not available' );
 		}
@@ -65,7 +64,7 @@ class ShortUrlPropertyAnnotator implements PropertyAnnotator {
 		$shortUrl = $this->getShortUrl( $semanticData->getSubject()->getTitle() );
 
 		if ( $shortUrl !== null ) {
-			$dataItem = new DIUri( 'http', $shortUrl, '', '' );
+			$dataItem = new Uri( 'http', $shortUrl, '', '' );
 		}
 
 		if ( $dataItem instanceof DataItem ) {

--- a/src/PropertyAnnotators/SubPagePropertyAnnotator.php
+++ b/src/PropertyAnnotators/SubPagePropertyAnnotator.php
@@ -7,6 +7,7 @@ use SESP\PropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
+
 /**
  * @private
  * @ingroup SESP

--- a/src/PropertyAnnotators/SubPagePropertyAnnotator.php
+++ b/src/PropertyAnnotators/SubPagePropertyAnnotator.php
@@ -4,10 +4,9 @@ namespace SESP\PropertyAnnotators;
 
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DIProperty;
-use SMW\DIWikiPage;
-use SMW\SemanticData;
-
+use SMW\DataItems\Property;
+use SMW\DataItems\WikiPage;
+use SMW\DataModel\SemanticData;
 /**
  * @private
  * @ingroup SESP
@@ -43,7 +42,7 @@ class SubPagePropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function isAnnotatorFor( DIProperty $property ) {
+	public function isAnnotatorFor( Property $property ) {
 		return $property->getKey() === self::PROP_ID;
 	}
 
@@ -52,7 +51,7 @@ class SubPagePropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function addAnnotation( DIProperty $property, SemanticData $semanticData ) {
+	public function addAnnotation( Property $property, SemanticData $semanticData ) {
 		$title = $semanticData->getSubject()->getTitle();
 
 		// -1 = no limit. Returns TitleArray object
@@ -61,7 +60,7 @@ class SubPagePropertyAnnotator implements PropertyAnnotator {
 		foreach ( $subpages as $title ) {
 			$semanticData->addPropertyObjectValue(
 				$property,
-				DIWikiPage::newFromTitle( $title )
+				WikiPage::newFromTitle( $title )
 			);
 		}
 	}

--- a/src/PropertyAnnotators/TalkPageNumRevisionPropertyAnnotator.php
+++ b/src/PropertyAnnotators/TalkPageNumRevisionPropertyAnnotator.php
@@ -4,10 +4,11 @@ namespace SESP\PropertyAnnotators;
 
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DataItems\Property;
-use SMW\DataModel\SemanticData;
 use SMW\DataItems\DataItem;
 use SMW\DataItems\Number;
+use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+
 /**
  * @private
  * @ingroup SESP

--- a/src/PropertyAnnotators/TalkPageNumRevisionPropertyAnnotator.php
+++ b/src/PropertyAnnotators/TalkPageNumRevisionPropertyAnnotator.php
@@ -4,11 +4,10 @@ namespace SESP\PropertyAnnotators;
 
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DIProperty;
-use SMW\SemanticData;
-use SMWDataItem as DataItem;
-use SMWDINumber as DINumber;
-
+use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+use SMW\DataItems\DataItem;
+use SMW\DataItems\Number;
 /**
  * @private
  * @ingroup SESP
@@ -44,7 +43,7 @@ class TalkPageNumRevisionPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function isAnnotatorFor( DIProperty $property ) {
+	public function isAnnotatorFor( Property $property ) {
 		return $property->getKey() === self::PROP_ID;
 	}
 
@@ -53,7 +52,7 @@ class TalkPageNumRevisionPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function addAnnotation( DIProperty $property, SemanticData $semanticData ) {
+	public function addAnnotation( Property $property, SemanticData $semanticData ) {
 		$title = $semanticData->getSubject()->getTitle()->getTalkPage();
 
 		$numRevisions = $this->getPageRevisions(
@@ -63,7 +62,7 @@ class TalkPageNumRevisionPropertyAnnotator implements PropertyAnnotator {
 		$dataItem = null;
 
 		if ( $title->exists() && $numRevisions > 0 ) {
-			$dataItem = new DINumber( $numRevisions );
+			$dataItem = new Number( $numRevisions );
 		}
 
 		if ( $dataItem instanceof DataItem ) {

--- a/src/PropertyAnnotators/UserBlockPropertyAnnotator.php
+++ b/src/PropertyAnnotators/UserBlockPropertyAnnotator.php
@@ -4,9 +4,9 @@ namespace SESP\PropertyAnnotators;
 
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DIProperty;
-use SMW\SemanticData;
-use SMWDIBlob as DIBlob;
+use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+use SMW\DataItems\Blob;
 use User;
 
 /**
@@ -44,7 +44,7 @@ class UserBlockPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function isAnnotatorFor( DIProperty $property ) {
+	public function isAnnotatorFor( Property $property ) {
 		return $property->getKey() === self::PROP_ID;
 	}
 
@@ -53,7 +53,7 @@ class UserBlockPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function addAnnotation( DIProperty $property, SemanticData $semanticData ) {
+	public function addAnnotation( Property $property, SemanticData $semanticData ) {
 		$title = $semanticData->getSubject()->getTitle();
 
 		if ( !$title->inNamespace( NS_USER ) ) {
@@ -78,7 +78,7 @@ class UserBlockPropertyAnnotator implements PropertyAnnotator {
 
 		foreach ( $actions as $action ) {
 			if ( $block->appliesToRight( $action ) ) {
-				$semanticData->addPropertyObjectValue( $property, new DIBlob( $action ) );
+				$semanticData->addPropertyObjectValue( $property, new Blob( $action ) );
 			}
 		}
 	}

--- a/src/PropertyAnnotators/UserBlockPropertyAnnotator.php
+++ b/src/PropertyAnnotators/UserBlockPropertyAnnotator.php
@@ -4,9 +4,9 @@ namespace SESP\PropertyAnnotators;
 
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
+use SMW\DataItems\Blob;
 use SMW\DataItems\Property;
 use SMW\DataModel\SemanticData;
-use SMW\DataItems\Blob;
 use User;
 
 /**

--- a/src/PropertyAnnotators/UserEditCountPerNsPropertyAnnotator.php
+++ b/src/PropertyAnnotators/UserEditCountPerNsPropertyAnnotator.php
@@ -4,13 +4,13 @@ namespace SESP\PropertyAnnotators;
 
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DataModel\ContainerSemanticData;
+use SMW\DataItems\Container;
+use SMW\DataItems\DataItem;
+use SMW\DataItems\Number;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
+use SMW\DataModel\ContainerSemanticData;
 use SMW\DataModel\SemanticData;
-use SMW\DataItems\DataItem;
-use SMW\DataItems\Container;
-use SMW\DataItems\Number;
 use User;
 use Wikimedia\IPUtils;
 

--- a/src/PropertyAnnotators/UserEditCountPerNsPropertyAnnotator.php
+++ b/src/PropertyAnnotators/UserEditCountPerNsPropertyAnnotator.php
@@ -5,12 +5,12 @@ namespace SESP\PropertyAnnotators;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
 use SMW\DataModel\ContainerSemanticData;
-use SMW\DIProperty;
-use SMW\DIWikiPage;
-use SMW\SemanticData;
-use SMWDataItem as DataItem;
-use SMWDIContainer as DIContainer;
-use SMWDINumber as DINumber;
+use SMW\DataItems\Property;
+use SMW\DataItems\WikiPage;
+use SMW\DataModel\SemanticData;
+use SMW\DataItems\DataItem;
+use SMW\DataItems\Container;
+use SMW\DataItems\Number;
 use User;
 use Wikimedia\IPUtils;
 
@@ -33,9 +33,9 @@ class UserEditCountPerNsPropertyAnnotator implements PropertyAnnotator {
 	/** @const string PROP_CNT_ID ID for the edit count in the record. */
 	private const PROP_CNT_ID = '___USEREDITCNTNS_CNT';
 
-	/** @var DIProperty DIProperty object for namespace number. */
+	/** @var Property Property object for namespace number. */
 	private static $nsProperty;
-	/** @var DIProperty DIProperty object for number if edits in NS. */
+	/** @var Property Property object for number if edits in NS. */
 	private static $editsProperty;
 
 	/** @var AppFactory */
@@ -46,21 +46,21 @@ class UserEditCountPerNsPropertyAnnotator implements PropertyAnnotator {
 	 */
 	public function __construct( AppFactory $appFactory ) {
 		$this->appFactory = $appFactory;
-		self::$nsProperty = self::$nsProperty ?: new DIProperty( self::PROP_NS_ID );
-		self::$editsProperty = self::$editsProperty ?: new DIProperty( self::PROP_CNT_ID );
+		self::$nsProperty = self::$nsProperty ?: new Property( self::PROP_NS_ID );
+		self::$editsProperty = self::$editsProperty ?: new Property( self::PROP_CNT_ID );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public function isAnnotatorFor( DIProperty $property ) {
+	public function isAnnotatorFor( Property $property ) {
 		return $property->getKey() === self::PROP_ID;
 	}
 
 	/**
 	 * @inheritDoc
 	 */
-	public function addAnnotation( DIProperty $property, SemanticData $semanticData ) {
+	public function addAnnotation( Property $property, SemanticData $semanticData ) {
 		$subject = $semanticData->getSubject();
 		$title = $subject->getTitle();
 
@@ -89,23 +89,23 @@ class UserEditCountPerNsPropertyAnnotator implements PropertyAnnotator {
 	}
 
 	/**
-	 * Form a DIContainer holding namespace and number of edits.
+	 * Form a Container holding namespace and number of edits.
 	 *
-	 * @param DIWikiPage $subject User page
+	 * @param WikiPage $subject User page
 	 * @param int $ns Namespace
 	 * @param int $edits Number of edits
-	 * @return DIContainer
+	 * @return Container
 	 */
-	public static function container( DIWikiPage $subject, $ns, $edits ): DIContainer {
-		$container = new ContainerSemanticData( new DIWikiPage(
+	public static function container( WikiPage $subject, $ns, $edits ): Container {
+		$container = new ContainerSemanticData( new WikiPage(
 			$subject->getDBkey(),
 			$subject->getNamespace(),
 			$subject->getInterwiki(),
 			'_USEREDITCNTNS' . (string)$ns
 		), false );
-		$container->addPropertyObjectValue( self::$nsProperty, new DINumber( $ns ) );
-		$container->addPropertyObjectValue( self::$editsProperty, new DINumber( $edits ) );
-		return new DIContainer( $container );
+		$container->addPropertyObjectValue( self::$nsProperty, new Number( $ns ) );
+		$container->addPropertyObjectValue( self::$editsProperty, new Number( $edits ) );
+		return new Container( $container );
 	}
 
 	/**

--- a/src/PropertyAnnotators/UserEditCountPropertyAnnotator.php
+++ b/src/PropertyAnnotators/UserEditCountPropertyAnnotator.php
@@ -4,10 +4,10 @@ namespace SESP\PropertyAnnotators;
 
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DataItems\Property;
-use SMW\DataModel\SemanticData;
 use SMW\DataItems\DataItem;
 use SMW\DataItems\Number;
+use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
 use User;
 
 /**

--- a/src/PropertyAnnotators/UserEditCountPropertyAnnotator.php
+++ b/src/PropertyAnnotators/UserEditCountPropertyAnnotator.php
@@ -4,10 +4,10 @@ namespace SESP\PropertyAnnotators;
 
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DIProperty;
-use SMW\SemanticData;
-use SMWDataItem as DataItem;
-use SMWDINumber as DINumber;
+use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+use SMW\DataItems\DataItem;
+use SMW\DataItems\Number;
 use User;
 
 /**
@@ -45,7 +45,7 @@ class UserEditCountPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function isAnnotatorFor( DIProperty $property ) {
+	public function isAnnotatorFor( Property $property ) {
 		return $property->getKey() === self::PROP_ID;
 	}
 
@@ -54,7 +54,7 @@ class UserEditCountPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function addAnnotation( DIProperty $property, SemanticData $semanticData ) {
+	public function addAnnotation( Property $property, SemanticData $semanticData ) {
 		$title = $semanticData->getSubject()->getTitle();
 
 		if ( !$title->inNamespace( NS_USER ) ) {
@@ -65,7 +65,7 @@ class UserEditCountPropertyAnnotator implements PropertyAnnotator {
 		$dataItem = null;
 
 		if ( $user instanceof User && ( $count = $user->getEditCount() ) && is_int( $count ) ) {
-			$dataItem = new DINumber( $count );
+			$dataItem = new Number( $count );
 		}
 
 		if ( $dataItem instanceof DataItem ) {

--- a/src/PropertyAnnotators/UserGroupPropertyAnnotator.php
+++ b/src/PropertyAnnotators/UserGroupPropertyAnnotator.php
@@ -5,9 +5,9 @@ namespace SESP\PropertyAnnotators;
 use MediaWiki\MediaWikiServices;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DIProperty;
-use SMW\SemanticData;
-use SMWDIBlob as DIBlob;
+use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+use SMW\DataItems\Blob;
 use User;
 
 /**
@@ -45,7 +45,7 @@ class UserGroupPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function isAnnotatorFor( DIProperty $property ) {
+	public function isAnnotatorFor( Property $property ) {
 		return $property->getKey() === self::PROP_ID;
 	}
 
@@ -54,7 +54,7 @@ class UserGroupPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function addAnnotation( DIProperty $property, SemanticData $semanticData ) {
+	public function addAnnotation( Property $property, SemanticData $semanticData ) {
 		$title = $semanticData->getSubject()->getTitle();
 
 		if ( !$title->inNamespace( NS_USER ) ) {
@@ -71,7 +71,7 @@ class UserGroupPropertyAnnotator implements PropertyAnnotator {
 
 		$groups = MediaWikiServices::getInstance()->getUserGroupManager()->getUserGroups( $user );
 		foreach ( $groups as $group ) {
-			$semanticData->addPropertyObjectValue( $property, new DIBlob( $group ) );
+			$semanticData->addPropertyObjectValue( $property, new Blob( $group ) );
 		}
 	}
 

--- a/src/PropertyAnnotators/UserGroupPropertyAnnotator.php
+++ b/src/PropertyAnnotators/UserGroupPropertyAnnotator.php
@@ -5,9 +5,9 @@ namespace SESP\PropertyAnnotators;
 use MediaWiki\MediaWikiServices;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
+use SMW\DataItems\Blob;
 use SMW\DataItems\Property;
 use SMW\DataModel\SemanticData;
-use SMW\DataItems\Blob;
 use User;
 
 /**

--- a/src/PropertyAnnotators/UserRegistrationDatePropertyAnnotator.php
+++ b/src/PropertyAnnotators/UserRegistrationDatePropertyAnnotator.php
@@ -4,10 +4,10 @@ namespace SESP\PropertyAnnotators;
 
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DIProperty;
-use SMW\SemanticData;
-use SMWDataItem as DataItem;
-use SMWDITime as DITime;
+use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+use SMW\DataItems\DataItem;
+use SMW\DataItems\Time;
 use User;
 
 /**
@@ -45,7 +45,7 @@ class UserRegistrationDatePropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function isAnnotatorFor( DIProperty $property ) {
+	public function isAnnotatorFor( Property $property ) {
 		return $property->getKey() === self::PROP_ID;
 	}
 
@@ -54,7 +54,7 @@ class UserRegistrationDatePropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function addAnnotation( DIProperty $property, SemanticData $semanticData ) {
+	public function addAnnotation( Property $property, SemanticData $semanticData ) {
 		$title = $semanticData->getSubject()->getTitle();
 
 		if ( !$title->inNamespace( NS_USER ) ) {
@@ -69,8 +69,8 @@ class UserRegistrationDatePropertyAnnotator implements PropertyAnnotator {
 			$timestamp = wfTimestamp( TS_ISO_8601, $user->getRegistration() );
 			$date = new \DateTime( $timestamp );
 
-			$dataItem = new DITime(
-				DITime::CM_GREGORIAN,
+			$dataItem = new Time(
+				Time::CM_GREGORIAN,
 				$date->format( 'Y' ),
 				$date->format( 'm' ),
 				$date->format( 'd' ),

--- a/src/PropertyAnnotators/UserRegistrationDatePropertyAnnotator.php
+++ b/src/PropertyAnnotators/UserRegistrationDatePropertyAnnotator.php
@@ -4,10 +4,10 @@ namespace SESP\PropertyAnnotators;
 
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DataItems\Property;
-use SMW\DataModel\SemanticData;
 use SMW\DataItems\DataItem;
+use SMW\DataItems\Property;
 use SMW\DataItems\Time;
+use SMW\DataModel\SemanticData;
 use User;
 
 /**

--- a/src/PropertyAnnotators/UserRightPropertyAnnotator.php
+++ b/src/PropertyAnnotators/UserRightPropertyAnnotator.php
@@ -6,9 +6,9 @@ use MediaWiki\MediaWikiServices;
 use MediaWiki\Permissions\PermissionManager;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
+use SMW\DataItems\Blob;
 use SMW\DataItems\Property;
 use SMW\DataModel\SemanticData;
-use SMW\DataItems\Blob;
 use User;
 
 /**

--- a/src/PropertyAnnotators/UserRightPropertyAnnotator.php
+++ b/src/PropertyAnnotators/UserRightPropertyAnnotator.php
@@ -6,9 +6,9 @@ use MediaWiki\MediaWikiServices;
 use MediaWiki\Permissions\PermissionManager;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
-use SMW\DIProperty;
-use SMW\SemanticData;
-use SMWDIBlob as DIBlob;
+use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+use SMW\DataItems\Blob;
 use User;
 
 /**
@@ -52,7 +52,7 @@ class UserRightPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function isAnnotatorFor( DIProperty $property ) {
+	public function isAnnotatorFor( Property $property ) {
 		return $property->getKey() === self::PROP_ID;
 	}
 
@@ -61,7 +61,7 @@ class UserRightPropertyAnnotator implements PropertyAnnotator {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function addAnnotation( DIProperty $property, SemanticData $semanticData ) {
+	public function addAnnotation( Property $property, SemanticData $semanticData ) {
 		$title = $semanticData->getSubject()->getTitle();
 
 		if ( !$title->inNamespace( NS_USER ) ) {
@@ -77,7 +77,7 @@ class UserRightPropertyAnnotator implements PropertyAnnotator {
 		}
 
 		foreach ( $this->permissionManager->getUserPermissions( $user ) as $right ) {
-			$semanticData->addPropertyObjectValue( $property, new DIBlob( $right ) );
+			$semanticData->addPropertyObjectValue( $property, new Blob( $right ) );
 		}
 	}
 

--- a/src/PropertyRegistry.php
+++ b/src/PropertyRegistry.php
@@ -125,7 +125,7 @@ class PropertyRegistry {
 
 		$desc = isset( $definition['desc'] ) ? $definition['desc'] : '';
 
-		$propertyRegistry->registerPropertyDescriptionMsgKeyById(
+		$propertyRegistry->registerPropertyDescriptionByMsgKey(
 			$definition['id'],
 			$desc
 		);

--- a/tests/phpunit/Unit/ExtraPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/ExtraPropertyAnnotatorTest.php
@@ -5,6 +5,10 @@ namespace SESP\Tests;
 use SESP\ExtraPropertyAnnotator;
 use SESP\PropertyDefinitions;
 use SMW\DataItems\WikiPage;
+use SMW\DataModel\SemanticData;
+use SESP\AppFactory;
+use SESP\LabelFetcher;
+use SESP\PropertyAnnotator;
 /**
  * @covers \SESP\ExtraPropertyAnnotator
  * @group semantic-extra-special-properties
@@ -21,7 +25,7 @@ class ExtraPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->appFactory = $this->getMockBuilder( '\SESP\AppFactory' )
+		$this->appFactory = $this->getMockBuilder( AppFactory::class )
 			->disableOriginalConstructor()
 			->getMock();
 	}
@@ -34,7 +38,7 @@ class ExtraPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testaddAnnotationOnInvalidSubject() {
-		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
+		$semanticData = $this->getMockBuilder( SemanticData::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -49,7 +53,7 @@ class ExtraPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testAddAnnotationOnLocalDef() {
-		$appFactory = $this->getMockBuilder( '\SESP\AppFactory' )
+		$appFactory = $this->getMockBuilder( AppFactory::class )
 			->disableOriginalConstructor()
 			->onlyMethods( [ 'getPropertyDefinitions', 'getOption' ] )
 			->getMock();
@@ -65,7 +69,7 @@ class ExtraPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			'callback' => $callback
 		];
 
-		$labelFetcher = $this->getMockBuilder( '\SESP\LabelFetcher' )
+		$labelFetcher = $this->getMockBuilder( LabelFetcher::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -86,7 +90,7 @@ class ExtraPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->with( 'sespgEnabledPropertyList' )
 			->willReturn( $localPropertyDefinitions );
 
-		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
+		$semanticData = $this->getMockBuilder( SemanticData::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -102,7 +106,7 @@ class ExtraPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testAddAnnotationOnPredefined() {
-		$appFactory = $this->getMockBuilder( '\SESP\AppFactory' )
+		$appFactory = $this->getMockBuilder( AppFactory::class )
 			->disableOriginalConstructor()
 			->onlyMethods( [ 'getPropertyDefinitions', 'getOption' ] )
 			->getMock();
@@ -115,7 +119,7 @@ class ExtraPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			'id'    => 'FAKE2'
 		];
 
-		$labelFetcher = $this->getMockBuilder( '\SESP\LabelFetcher' )
+		$labelFetcher = $this->getMockBuilder( LabelFetcher::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -136,7 +140,7 @@ class ExtraPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->with( 'sespgEnabledPropertyList' )
 			->willReturn( $specialProperties );
 
-		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
+		$semanticData = $this->getMockBuilder( SemanticData::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -144,7 +148,7 @@ class ExtraPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getSubject' )
 			->willReturn( $subject );
 
-		$propertyAnnotator = $this->getMockBuilder( '\SESP\PropertyAnnotator' )
+		$propertyAnnotator = $this->getMockBuilder( PropertyAnnotator::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/ExtraPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/ExtraPropertyAnnotatorTest.php
@@ -4,8 +4,7 @@ namespace SESP\Tests;
 
 use SESP\ExtraPropertyAnnotator;
 use SESP\PropertyDefinitions;
-use SMW\DIWikiPage;
-
+use SMW\DataItems\WikiPage;
 /**
  * @covers \SESP\ExtraPropertyAnnotator
  * @group semantic-extra-special-properties
@@ -35,7 +34,7 @@ class ExtraPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testaddAnnotationOnInvalidSubject() {
-		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -55,7 +54,7 @@ class ExtraPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->onlyMethods( [ 'getPropertyDefinitions', 'getOption' ] )
 			->getMock();
 
-		$subject = DIWikiPage::newFromText( __METHOD__ );
+		$subject = WikiPage::newFromText( __METHOD__ );
 
 		$callback = static function ( $appFactory, $property, $semanticData ) {
 			return $semanticData->getSubject();
@@ -87,7 +86,7 @@ class ExtraPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->with( 'sespgEnabledPropertyList' )
 			->willReturn( $localPropertyDefinitions );
 
-		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -108,7 +107,7 @@ class ExtraPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->onlyMethods( [ 'getPropertyDefinitions', 'getOption' ] )
 			->getMock();
 
-		$subject = DIWikiPage::newFromText( __METHOD__ );
+		$subject = WikiPage::newFromText( __METHOD__ );
 
 		$specialProperties = [ 'FAKE2' ];
 
@@ -137,7 +136,7 @@ class ExtraPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->with( 'sespgEnabledPropertyList' )
 			->willReturn( $specialProperties );
 
-		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/ExtraPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/ExtraPropertyAnnotatorTest.php
@@ -2,13 +2,14 @@
 
 namespace SESP\Tests;
 
+use SESP\AppFactory;
 use SESP\ExtraPropertyAnnotator;
+use SESP\LabelFetcher;
+use SESP\PropertyAnnotator;
 use SESP\PropertyDefinitions;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
-use SESP\AppFactory;
-use SESP\LabelFetcher;
-use SESP\PropertyAnnotator;
+
 /**
  * @covers \SESP\ExtraPropertyAnnotator
  * @group semantic-extra-special-properties

--- a/tests/phpunit/Unit/HookRegistryTest.php
+++ b/tests/phpunit/Unit/HookRegistryTest.php
@@ -3,6 +3,9 @@
 namespace SESP\Tests;
 
 use SESP\HookRegistry;
+use SMW\DataModel\SemanticData;
+use SMW\PropertyRegistry;
+use SMW\Store;
 
 /**
  * @covers \SESP\HookRegistry
@@ -86,7 +89,7 @@ class HookRegistryTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function doTestRegisteredInitPropertiesHandler( $instance ) {
-		$propertyRegistry = $this->getMockBuilder( '\SMW\PropertyRegistry' )
+		$propertyRegistry = $this->getMockBuilder( PropertyRegistry::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -119,11 +122,11 @@ class HookRegistryTest extends \PHPUnit\Framework\TestCase {
 			$instance->isRegistered( 'SMW::Store::BeforeDataUpdateComplete' )
 		);
 
-		$store = $this->getMockBuilder( '\SMW\Store' )
+		$store = $this->getMockBuilder( Store::class )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
+		$semanticData = $this->getMockBuilder( SemanticData::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/HookRegistryTest.php
+++ b/tests/phpunit/Unit/HookRegistryTest.php
@@ -123,7 +123,7 @@ class HookRegistryTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/LabelFetcherTest.php
+++ b/tests/phpunit/Unit/LabelFetcherTest.php
@@ -3,6 +3,8 @@
 namespace SESP\Tests;
 
 use SESP\LabelFetcher;
+use SESP\PropertyDefinitions;
+use Onoi\Cache\Cache;
 
 /**
  * @covers \SESP\LabelFetcher
@@ -20,7 +22,7 @@ class LabelFetcherTest extends \PHPUnit\Framework\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+		$this->cache = $this->getMockBuilder( Cache::class )
 			->disableOriginalConstructor()
 			->getMock();
 	}
@@ -50,7 +52,7 @@ class LabelFetcherTest extends \PHPUnit\Framework\TestCase {
 			]
 		];
 
-		$propertyDefinitions = $this->getMockBuilder( '\SESP\PropertyDefinitions' )
+		$propertyDefinitions = $this->getMockBuilder( PropertyDefinitions::class )
 			->disableOriginalConstructor()
 			->addMethods( [] )
 			->getMock();
@@ -80,7 +82,7 @@ class LabelFetcherTest extends \PHPUnit\Framework\TestCase {
 			'FOO' => 'Bar'
 		];
 
-		$propertyDefinitions = $this->getMockBuilder( '\SESP\PropertyDefinitions' )
+		$propertyDefinitions = $this->getMockBuilder( PropertyDefinitions::class )
 			->disableOriginalConstructor()
 			->onlyMethods( [ 'getLabels' ] )
 			->getMock();
@@ -104,7 +106,7 @@ class LabelFetcherTest extends \PHPUnit\Framework\TestCase {
 			'FOO' => 'Bar'
 		];
 
-		$propertyDefinitions = $this->getMockBuilder( '\SESP\PropertyDefinitions' )
+		$propertyDefinitions = $this->getMockBuilder( PropertyDefinitions::class )
 			->disableOriginalConstructor()
 			->onlyMethods( [] )
 			->getMock();

--- a/tests/phpunit/Unit/LabelFetcherTest.php
+++ b/tests/phpunit/Unit/LabelFetcherTest.php
@@ -2,9 +2,9 @@
 
 namespace SESP\Tests;
 
+use Onoi\Cache\Cache;
 use SESP\LabelFetcher;
 use SESP\PropertyDefinitions;
-use Onoi\Cache\Cache;
 
 /**
  * @covers \SESP\LabelFetcher

--- a/tests/phpunit/Unit/PropertyAnnotators/ApprovedByPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ApprovedByPropertyAnnotatorTest.php
@@ -6,6 +6,8 @@ use SESP\PropertyAnnotators\ApprovedByPropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use User;
+use SMW\DataModel\SemanticData;
+use SESP\AppFactory;
 
 /**
  * @covers \SESP\PropertyAnnotators\ApprovedByPropertyAnnotator
@@ -24,7 +26,7 @@ class ApprovedByPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->appFactory = $this->getMockBuilder( '\SESP\AppFactory' )
+		$this->appFactory = $this->getMockBuilder( AppFactory::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -50,7 +52,7 @@ class ApprovedByPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 
 	public function testAddAnnotation() {
 		$user = User::newFromName( "UnitTest" );
-		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
+		$semanticData = $this->getMockBuilder( SemanticData::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -69,7 +71,7 @@ class ApprovedByPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testRemoval() {
-		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
+		$semanticData = $this->getMockBuilder( SemanticData::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/ApprovedByPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ApprovedByPropertyAnnotatorTest.php
@@ -2,12 +2,12 @@
 
 namespace SESP\Tests\PropertyAnnotators;
 
+use SESP\AppFactory;
 use SESP\PropertyAnnotators\ApprovedByPropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
-use User;
 use SMW\DataModel\SemanticData;
-use SESP\AppFactory;
+use User;
 
 /**
  * @covers \SESP\PropertyAnnotators\ApprovedByPropertyAnnotator

--- a/tests/phpunit/Unit/PropertyAnnotators/ApprovedByPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ApprovedByPropertyAnnotatorTest.php
@@ -3,8 +3,8 @@
 namespace SESP\Tests\PropertyAnnotators;
 
 use SESP\PropertyAnnotators\ApprovedByPropertyAnnotator;
-use SMW\DIProperty;
-use SMW\DIWikiPage;
+use SMW\DataItems\Property;
+use SMW\DataItems\WikiPage;
 use User;
 
 /**
@@ -28,7 +28,7 @@ class ApprovedByPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->property = new DIProperty( '___APPROVEDBY' );
+		$this->property = new Property( '___APPROVEDBY' );
 	}
 
 	public function testCanConstruct() {
@@ -50,7 +50,7 @@ class ApprovedByPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 
 	public function testAddAnnotation() {
 		$user = User::newFromName( "UnitTest" );
-		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -58,7 +58,7 @@ class ApprovedByPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'addPropertyObjectValue' )
 			->with(
 				$this->property,
-				DIWikiPage::newFromTitle( $user->getUserPage() ) );
+				WikiPage::newFromTitle( $user->getUserPage() ) );
 		$annotator = new ApprovedByPropertyAnnotator(
 			$this->appFactory
 		);
@@ -69,7 +69,7 @@ class ApprovedByPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testRemoval() {
-		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/ApprovedDatePropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ApprovedDatePropertyAnnotatorTest.php
@@ -4,9 +4,8 @@ namespace SESP\Tests\PropertyAnnotators;
 
 use MWTimestamp;
 use SESP\PropertyAnnotators\ApprovedDatePropertyAnnotator;
-use SMW\DIProperty;
-use SMWDITime as DITime;
-
+use SMW\DataItems\Property;
+use SMW\DataItems\Time;
 /**
  * @covers \SESP\PropertyAnnotators\ApprovedDatePropertyAnnotator
  * @group semantic-extra-special-properties
@@ -28,7 +27,7 @@ class ApprovedDatePropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->property = new DIProperty( '___APPROVEDDATE' );
+		$this->property = new Property( '___APPROVEDDATE' );
 	}
 
 	public function testCanConstruct() {
@@ -49,8 +48,8 @@ class ApprovedDatePropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	protected static function getDITime( MWTimestamp $time ) {
-		return new DITime(
-				DITime::CM_GREGORIAN,
+		return new Time(
+				Time::CM_GREGORIAN,
 				$time->format( 'Y' ),
 				$time->format( 'm' ),
 				$time->format( 'd' ),
@@ -62,7 +61,7 @@ class ApprovedDatePropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	public function testAddAnnotation() {
 		$now = new MWTimestamp( wfTimestampNow() );
 		$time = self::getDITime( $now );
-		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -82,7 +81,7 @@ class ApprovedDatePropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testRemoval() {
-		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/ApprovedDatePropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ApprovedDatePropertyAnnotatorTest.php
@@ -6,6 +6,8 @@ use MWTimestamp;
 use SESP\PropertyAnnotators\ApprovedDatePropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataItems\Time;
+use SMW\DataModel\SemanticData;
+use SESP\AppFactory;
 /**
  * @covers \SESP\PropertyAnnotators\ApprovedDatePropertyAnnotator
  * @group semantic-extra-special-properties
@@ -23,7 +25,7 @@ class ApprovedDatePropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->appFactory = $this->getMockBuilder( '\SESP\AppFactory' )
+		$this->appFactory = $this->getMockBuilder( AppFactory::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -61,7 +63,7 @@ class ApprovedDatePropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	public function testAddAnnotation() {
 		$now = new MWTimestamp( wfTimestampNow() );
 		$time = self::getDITime( $now );
-		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
+		$semanticData = $this->getMockBuilder( SemanticData::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -81,7 +83,7 @@ class ApprovedDatePropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testRemoval() {
-		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
+		$semanticData = $this->getMockBuilder( SemanticData::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/ApprovedDatePropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ApprovedDatePropertyAnnotatorTest.php
@@ -3,11 +3,12 @@
 namespace SESP\Tests\PropertyAnnotators;
 
 use MWTimestamp;
+use SESP\AppFactory;
 use SESP\PropertyAnnotators\ApprovedDatePropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataItems\Time;
 use SMW\DataModel\SemanticData;
-use SESP\AppFactory;
+
 /**
  * @covers \SESP\PropertyAnnotators\ApprovedDatePropertyAnnotator
  * @group semantic-extra-special-properties

--- a/tests/phpunit/Unit/PropertyAnnotators/ApprovedRevPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ApprovedRevPropertyAnnotatorTest.php
@@ -2,11 +2,12 @@
 
 namespace SESP\Tests\PropertyAnnotators;
 
-use SESP\PropertyAnnotators\ApprovedRevPropertyAnnotator;
-use SMW\DataItems\Property;
-use SMW\DataItems\Number;
-use SMW\DataModel\SemanticData;
 use SESP\AppFactory;
+use SESP\PropertyAnnotators\ApprovedRevPropertyAnnotator;
+use SMW\DataItems\Number;
+use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+
 /**
  * @covers \SESP\PropertyAnnotators\ApprovedRevPropertyAnnotator
  * @group semantic-extra-special-properties

--- a/tests/phpunit/Unit/PropertyAnnotators/ApprovedRevPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ApprovedRevPropertyAnnotatorTest.php
@@ -3,9 +3,8 @@
 namespace SESP\Tests\PropertyAnnotators;
 
 use SESP\PropertyAnnotators\ApprovedRevPropertyAnnotator;
-use SMW\DIProperty;
-use SMWDINumber as DINumber;
-
+use SMW\DataItems\Property;
+use SMW\DataItems\Number;
 /**
  * @covers \SESP\PropertyAnnotators\ApprovedRevPropertyAnnotator
  * @group semantic-extra-special-properties
@@ -27,7 +26,7 @@ class ApprovedRevPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->property = new DIProperty( '___APPROVED' );
+		$this->property = new Property( '___APPROVED' );
 	}
 
 	public function testCanConstruct() {
@@ -48,7 +47,7 @@ class ApprovedRevPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testAddAnnotation() {
-		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -56,7 +55,7 @@ class ApprovedRevPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'addPropertyObjectValue' )
 			->with(
 				$this->property,
-				new DINumber( 42 ) );
+				new Number( 42 ) );
 
 		$annotator = new ApprovedRevPropertyAnnotator(
 			$this->appFactory
@@ -68,7 +67,7 @@ class ApprovedRevPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testRemoval() {
-		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/ApprovedRevPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ApprovedRevPropertyAnnotatorTest.php
@@ -5,6 +5,8 @@ namespace SESP\Tests\PropertyAnnotators;
 use SESP\PropertyAnnotators\ApprovedRevPropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataItems\Number;
+use SMW\DataModel\SemanticData;
+use SESP\AppFactory;
 /**
  * @covers \SESP\PropertyAnnotators\ApprovedRevPropertyAnnotator
  * @group semantic-extra-special-properties
@@ -22,7 +24,7 @@ class ApprovedRevPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->appFactory = $this->getMockBuilder( '\SESP\AppFactory' )
+		$this->appFactory = $this->getMockBuilder( AppFactory::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -47,7 +49,7 @@ class ApprovedRevPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testAddAnnotation() {
-		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
+		$semanticData = $this->getMockBuilder( SemanticData::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -67,7 +69,7 @@ class ApprovedRevPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testRemoval() {
-		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
+		$semanticData = $this->getMockBuilder( SemanticData::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/ApprovedStatusPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ApprovedStatusPropertyAnnotatorTest.php
@@ -4,7 +4,7 @@ namespace SESP\Tests\PropertyAnnotators;
 
 use SESP\PropertyAnnotators\ApprovedStatusPropertyAnnotator;
 use SMW\DataItems\Property;
-use Blob as DIString;
+use SMW\DataItems\Blob as DIString;
 
 /**
  * @covers \SESP\PropertyAnnotators\ApprovedStatusPropertyAnnotator

--- a/tests/phpunit/Unit/PropertyAnnotators/ApprovedStatusPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ApprovedStatusPropertyAnnotatorTest.php
@@ -2,11 +2,11 @@
 
 namespace SESP\Tests\PropertyAnnotators;
 
-use SESP\PropertyAnnotators\ApprovedStatusPropertyAnnotator;
-use SMW\DataItems\Property;
-use SMW\DataItems\Blob as DIString;
-use SMW\DataModel\SemanticData;
 use SESP\AppFactory;
+use SESP\PropertyAnnotators\ApprovedStatusPropertyAnnotator;
+use SMW\DataItems\Blob as DIString;
+use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
 
 /**
  * @covers \SESP\PropertyAnnotators\ApprovedStatusPropertyAnnotator

--- a/tests/phpunit/Unit/PropertyAnnotators/ApprovedStatusPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ApprovedStatusPropertyAnnotatorTest.php
@@ -5,6 +5,8 @@ namespace SESP\Tests\PropertyAnnotators;
 use SESP\PropertyAnnotators\ApprovedStatusPropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataItems\Blob as DIString;
+use SMW\DataModel\SemanticData;
+use SESP\AppFactory;
 
 /**
  * @covers \SESP\PropertyAnnotators\ApprovedStatusPropertyAnnotator
@@ -23,7 +25,7 @@ class ApprovedStatusPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->appFactory = $this->getMockBuilder( '\SESP\AppFactory' )
+		$this->appFactory = $this->getMockBuilder( AppFactory::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -48,7 +50,7 @@ class ApprovedStatusPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testAddAnnotation() {
-		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
+		$semanticData = $this->getMockBuilder( SemanticData::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -68,7 +70,7 @@ class ApprovedStatusPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testRemoval() {
-		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
+		$semanticData = $this->getMockBuilder( SemanticData::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/ApprovedStatusPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ApprovedStatusPropertyAnnotatorTest.php
@@ -3,8 +3,8 @@
 namespace SESP\Tests\PropertyAnnotators;
 
 use SESP\PropertyAnnotators\ApprovedStatusPropertyAnnotator;
-use SMW\DIProperty;
-use SMWDIBlob as DIString;
+use SMW\DataItems\Property;
+use Blob as DIString;
 
 /**
  * @covers \SESP\PropertyAnnotators\ApprovedStatusPropertyAnnotator
@@ -27,7 +27,7 @@ class ApprovedStatusPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->property = new DIProperty( '___APPROVEDSTATUS' );
+		$this->property = new Property( '___APPROVEDSTATUS' );
 	}
 
 	public function testCanConstruct() {
@@ -48,7 +48,7 @@ class ApprovedStatusPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testAddAnnotation() {
-		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -68,7 +68,7 @@ class ApprovedStatusPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testRemoval() {
-		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/CreatorPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/CreatorPropertyAnnotatorTest.php
@@ -4,9 +4,9 @@ namespace SESP\Tests\PropertyAnnotators;
 
 use SESP\AppFactory;
 use SESP\PropertyAnnotators\CreatorPropertyAnnotator;
-use SMW\DIProperty;
-use SMW\DIWikiPage;
-use SMW\SemanticData;
+use SMW\DataItems\Property;
+use SMW\DataItems\WikiPage as DIWikiPage;
+use SMW\DataModel\SemanticData;
 use User;
 use WikiPage;
 
@@ -31,7 +31,7 @@ class CreatorPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->property = new DIProperty( '___CUSER' );
+		$this->property = new Property( '___CUSER' );
 	}
 
 	public function testCanConstruct() {

--- a/tests/phpunit/Unit/PropertyAnnotators/DispatchingPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/DispatchingPropertyAnnotatorTest.php
@@ -28,8 +28,7 @@ use SESP\PropertyAnnotators\UserEditCountPropertyAnnotator;
 use SESP\PropertyAnnotators\UserGroupPropertyAnnotator;
 use SESP\PropertyAnnotators\UserRegistrationDatePropertyAnnotator;
 use SESP\PropertyAnnotators\UserRightPropertyAnnotator;
-use SMW\DIProperty;
-
+use SMW\DataItems\Property;
 /**
  * @covers \SESP\PropertyAnnotators\DispatchingPropertyAnnotator
  * @group semantic-extra-special-properties
@@ -51,7 +50,7 @@ class DispatchingPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->property = new DIProperty( 'Foo' );
+		$this->property = new Property( 'Foo' );
 	}
 
 	public function testCanConstruct() {
@@ -72,7 +71,7 @@ class DispatchingPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testAddAnnotation() {
-		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -89,7 +88,7 @@ class DispatchingPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 
 		$instance->addPropertyAnnotator( 'Foo', $propertyAnnotator );
 
-		$instance->addAnnotation( new DIProperty( 'Foo' ), $semanticData );
+		$instance->addAnnotation( new Property( 'Foo' ), $semanticData );
 	}
 
 	/**
@@ -102,7 +101,7 @@ class DispatchingPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 
 		$this->assertInstanceOf(
 			$expected,
-			$instance->findPropertyAnnotator( new DIProperty( $property ) )
+			$instance->findPropertyAnnotator( new Property( $property ) )
 		);
 	}
 

--- a/tests/phpunit/Unit/PropertyAnnotators/DispatchingPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/DispatchingPropertyAnnotatorTest.php
@@ -2,6 +2,8 @@
 
 namespace SESP\Tests\PropertyAnnotators;
 
+use SESP\AppFactory;
+use SESP\PropertyAnnotator;
 use SESP\PropertyAnnotators\ApprovedByPropertyAnnotator;
 use SESP\PropertyAnnotators\ApprovedDatePropertyAnnotator;
 use SESP\PropertyAnnotators\ApprovedRevPropertyAnnotator;
@@ -30,8 +32,7 @@ use SESP\PropertyAnnotators\UserRegistrationDatePropertyAnnotator;
 use SESP\PropertyAnnotators\UserRightPropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataModel\SemanticData;
-use SESP\AppFactory;
-use SESP\PropertyAnnotator;
+
 /**
  * @covers \SESP\PropertyAnnotators\DispatchingPropertyAnnotator
  * @group semantic-extra-special-properties

--- a/tests/phpunit/Unit/PropertyAnnotators/DispatchingPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/DispatchingPropertyAnnotatorTest.php
@@ -29,6 +29,9 @@ use SESP\PropertyAnnotators\UserGroupPropertyAnnotator;
 use SESP\PropertyAnnotators\UserRegistrationDatePropertyAnnotator;
 use SESP\PropertyAnnotators\UserRightPropertyAnnotator;
 use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+use SESP\AppFactory;
+use SESP\PropertyAnnotator;
 /**
  * @covers \SESP\PropertyAnnotators\DispatchingPropertyAnnotator
  * @group semantic-extra-special-properties
@@ -46,7 +49,7 @@ class DispatchingPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->appFactory = $this->getMockBuilder( '\SESP\AppFactory' )
+		$this->appFactory = $this->getMockBuilder( AppFactory::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -71,11 +74,11 @@ class DispatchingPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testAddAnnotation() {
-		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
+		$semanticData = $this->getMockBuilder( SemanticData::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$propertyAnnotator = $this->getMockBuilder( '\SESP\PropertyAnnotator' )
+		$propertyAnnotator = $this->getMockBuilder( PropertyAnnotator::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/ExifPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ExifPropertyAnnotatorTest.php
@@ -5,9 +5,8 @@ namespace SESP\Tests\PropertyAnnotators;
 use MediaWiki\Title\Title;
 use SESP\PropertyAnnotators\ExifPropertyAnnotator;
 use SESP\PropertyDefinitions;
-use SMW\DIProperty;
-use SMW\DIWikiPage;
-
+use SMW\DataItems\Property;
+use SMW\DataItems\WikiPage;
 /**
  * @covers \SESP\PropertyAnnotators\ExifPropertyAnnotator
  * @group semantic-extra-special-properties
@@ -29,7 +28,7 @@ class ExifPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->property = new DIProperty( '___EXIFDATA' );
+		$this->property = new Property( '___EXIFDATA' );
 	}
 
 	public function testCanConstruct() {
@@ -74,7 +73,7 @@ class ExifPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'inNamespace' )
 			->willReturn( true );
 
-		$subject = $this->getMockBuilder( '\SMW\DIWikiPage' )
+		$subject = $this->getMockBuilder( '\SMW\WikiPage' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -86,7 +85,7 @@ class ExifPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'newWikiPage' )
 			->willReturn( $wikiPage );
 
-		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -117,7 +116,7 @@ class ExifPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			$defs
 		);
 
-		$subject = DIWikiPage::newFromText( __METHOD__, NS_FILE );
+		$subject = WikiPage::newFromText( __METHOD__, NS_FILE );
 
 		$file = $this->getMockBuilder( 'File' )
 			->disableOriginalConstructor()
@@ -147,7 +146,7 @@ class ExifPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getPropertyDefinitions' )
 			->willReturn( $propertyDefinitions );
 
-		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/ExifPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ExifPropertyAnnotatorTest.php
@@ -7,6 +7,12 @@ use SESP\PropertyAnnotators\ExifPropertyAnnotator;
 use SESP\PropertyDefinitions;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
+use SMW\DataModel\SemanticData;
+use SESP\AppFactory;
+use SMW\DataItems\WikiPage as DIWikiPage;
+use SESP\LabelFetcher;
+use WikiFilePage;
+use File;
 /**
  * @covers \SESP\PropertyAnnotators\ExifPropertyAnnotator
  * @group semantic-extra-special-properties
@@ -24,7 +30,7 @@ class ExifPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->appFactory = $this->getMockBuilder( '\SESP\AppFactory' )
+		$this->appFactory = $this->getMockBuilder( AppFactory::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -49,7 +55,7 @@ class ExifPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testTryAddAnnotationForNonExistingFile() {
-		$file = $this->getMockBuilder( 'File' )
+		$file = $this->getMockBuilder( File::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -57,7 +63,7 @@ class ExifPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'exists' )
 			->willReturn( false );
 
-		$wikiPage = $this->getMockBuilder( '\WikiFilePage' )
+		$wikiPage = $this->getMockBuilder( WikiFilePage::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -73,7 +79,7 @@ class ExifPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'inNamespace' )
 			->willReturn( true );
 
-		$subject = $this->getMockBuilder( '\SMW\WikiPage' )
+		$subject = $this->getMockBuilder( DIWikiPage::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -85,7 +91,7 @@ class ExifPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'newWikiPage' )
 			->willReturn( $wikiPage );
 
-		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
+		$semanticData = $this->getMockBuilder( SemanticData::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -104,7 +110,7 @@ class ExifPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	 * @dataProvider metaProvider
 	 */
 	public function testAddAnnotation( $meta, $defs, $expected ) {
-		$labelFetcher = $this->getMockBuilder( '\SESP\LabelFetcher' )
+		$labelFetcher = $this->getMockBuilder( LabelFetcher::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -118,7 +124,7 @@ class ExifPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 
 		$subject = WikiPage::newFromText( __METHOD__, NS_FILE );
 
-		$file = $this->getMockBuilder( 'File' )
+		$file = $this->getMockBuilder( File::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -130,7 +136,7 @@ class ExifPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getMetadata' )
 			->willReturn( serialize( $meta ) );
 
-		$wikiPage = $this->getMockBuilder( '\WikiFilePage' )
+		$wikiPage = $this->getMockBuilder( WikiFilePage::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -146,7 +152,7 @@ class ExifPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getPropertyDefinitions' )
 			->willReturn( $propertyDefinitions );
 
-		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
+		$semanticData = $this->getMockBuilder( SemanticData::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/ExifPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ExifPropertyAnnotatorTest.php
@@ -10,7 +10,6 @@ use SESP\PropertyAnnotators\ExifPropertyAnnotator;
 use SESP\PropertyDefinitions;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
-use SMW\DataItems\WikiPage as DIWikiPage;
 use SMW\DataModel\SemanticData;
 use WikiFilePage;
 
@@ -80,7 +79,7 @@ class ExifPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'inNamespace' )
 			->willReturn( true );
 
-		$subject = $this->getMockBuilder( DIWikiPage::class )
+		$subject = $this->getMockBuilder( WikiPage::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/ExifPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ExifPropertyAnnotatorTest.php
@@ -2,17 +2,18 @@
 
 namespace SESP\Tests\PropertyAnnotators;
 
+use File;
 use MediaWiki\Title\Title;
+use SESP\AppFactory;
+use SESP\LabelFetcher;
 use SESP\PropertyAnnotators\ExifPropertyAnnotator;
 use SESP\PropertyDefinitions;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
-use SMW\DataModel\SemanticData;
-use SESP\AppFactory;
 use SMW\DataItems\WikiPage as DIWikiPage;
-use SESP\LabelFetcher;
+use SMW\DataModel\SemanticData;
 use WikiFilePage;
-use File;
+
 /**
  * @covers \SESP\PropertyAnnotators\ExifPropertyAnnotator
  * @group semantic-extra-special-properties

--- a/tests/phpunit/Unit/PropertyAnnotators/LinksToPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/LinksToPropertyAnnotatorTest.php
@@ -23,7 +23,7 @@ class LinksToPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->appFactory = $this->getMockBuilder( '\SESP\AppFactory' )
+		$this->appFactory = $this->getMockBuilder( AppFactory::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/LinksToPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/LinksToPropertyAnnotatorTest.php
@@ -5,10 +5,9 @@ namespace SESP\Tests\PropertyAnnotators;
 use MediaWiki\Title\Title;
 use SESP\AppFactory;
 use SESP\PropertyAnnotators\LinksToPropertyAnnotator;
-use SMW\DIProperty;
-use SMW\DIWikiPage;
-use SMW\SemanticData;
-
+use SMW\DataItems\Property;
+use SMW\DataItems\WikiPage;
+use SMW\DataModel\SemanticData;
 /**
  * @covers \SESP\PropertyAnnotators\LinksToPropertyAnnotator
  * @group semantic-extra-special-properties
@@ -28,7 +27,7 @@ class LinksToPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->property = new DIProperty( '___LINKSTO' );
+		$this->property = new Property( '___LINKSTO' );
 	}
 
 	public function testCanConstruct() {
@@ -55,7 +54,7 @@ class LinksToPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 
 		$factory->expects( $this->once() )->method( 'getConnection' );
 
-		$subject = $this->getMockBuilder( DIWikiPage::class )
+		$subject = $this->getMockBuilder( WikiPage::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -89,7 +88,7 @@ class LinksToPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 		$factory->expects( $this->never() )
 			->method( 'getConnection' );
 
-		$subject = $this->getMockBuilder( DIWikiPage::class )
+		$subject = $this->getMockBuilder( WikiPage::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/LinksToPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/LinksToPropertyAnnotatorTest.php
@@ -8,6 +8,7 @@ use SESP\PropertyAnnotators\LinksToPropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
+
 /**
  * @covers \SESP\PropertyAnnotators\LinksToPropertyAnnotator
  * @group semantic-extra-special-properties

--- a/tests/phpunit/Unit/PropertyAnnotators/LocalPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/LocalPropertyAnnotatorTest.php
@@ -5,6 +5,8 @@ namespace SESP\Tests\PropertyAnnotators;
 use SESP\PropertyAnnotators\LocalPropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
+use SMW\DataModel\SemanticData;
+use SESP\AppFactory;
 /**
  * @covers \SESP\PropertyAnnotators\LocalPropertyAnnotator
  * @group semantic-extra-special-properties
@@ -22,7 +24,7 @@ class LocalPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->appFactory = $this->getMockBuilder( '\SESP\AppFactory' )
+		$this->appFactory = $this->getMockBuilder( AppFactory::class )
 			->disableOriginalConstructor()
 			->onlyMethods( [ 'getOption' ] )
 			->getMock();
@@ -66,7 +68,7 @@ class LocalPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->with( 'sespgLocalDefinitions' )
 			->willReturn( $localPropertyDefinitions );
 
-		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
+		$semanticData = $this->getMockBuilder( SemanticData::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -95,7 +97,7 @@ class LocalPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->with( 'sespgLocalDefinitions' )
 			->willReturn( $localPropertyDefinitions );
 
-		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
+		$semanticData = $this->getMockBuilder( SemanticData::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/LocalPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/LocalPropertyAnnotatorTest.php
@@ -3,9 +3,8 @@
 namespace SESP\Tests\PropertyAnnotators;
 
 use SESP\PropertyAnnotators\LocalPropertyAnnotator;
-use SMW\DIProperty;
-use SMW\DIWikiPage;
-
+use SMW\DataItems\Property;
+use SMW\DataItems\WikiPage;
 /**
  * @covers \SESP\PropertyAnnotators\LocalPropertyAnnotator
  * @group semantic-extra-special-properties
@@ -28,7 +27,7 @@ class LocalPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->onlyMethods( [ 'getOption' ] )
 			->getMock();
 
-		$this->property = new DIProperty( 'FAKE_PROP' );
+		$this->property = new Property( 'FAKE_PROP' );
 	}
 
 	public function testCanConstruct() {
@@ -49,7 +48,7 @@ class LocalPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testAddAnnotation() {
-		$subject = DIWikiPage::newFromText( __METHOD__ );
+		$subject = WikiPage::newFromText( __METHOD__ );
 
 		$callback = static function ( $appFactory, $property, $semanticData ) {
 			return $semanticData->getSubject();
@@ -67,7 +66,7 @@ class LocalPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->with( 'sespgLocalDefinitions' )
 			->willReturn( $localPropertyDefinitions );
 
-		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -86,7 +85,7 @@ class LocalPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testAddAnnotationOnInvalidLocalDef() {
-		$subject = DIWikiPage::newFromText( __METHOD__ );
+		$subject = WikiPage::newFromText( __METHOD__ );
 
 		$localPropertyDefinitions = [];
 		$localPropertyDefinitions['FAKE_PROP'] = [];
@@ -96,7 +95,7 @@ class LocalPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->with( 'sespgLocalDefinitions' )
 			->willReturn( $localPropertyDefinitions );
 
-		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/LocalPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/LocalPropertyAnnotatorTest.php
@@ -2,11 +2,12 @@
 
 namespace SESP\Tests\PropertyAnnotators;
 
+use SESP\AppFactory;
 use SESP\PropertyAnnotators\LocalPropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
-use SESP\AppFactory;
+
 /**
  * @covers \SESP\PropertyAnnotators\LocalPropertyAnnotator
  * @group semantic-extra-special-properties

--- a/tests/phpunit/Unit/PropertyAnnotators/NamespaceNamePropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/NamespaceNamePropertyAnnotatorTest.php
@@ -6,6 +6,8 @@ use SESP\PropertyAnnotators\NamespaceNamePropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\DataItems\Blob;
+use SMW\DataModel\SemanticData;
+use SESP\AppFactory;
 /**
  * @covers \SESP\PropertyAnnotators\NamespacePropertyAnnotator
  * @group semantic-extra-special-properties
@@ -20,7 +22,7 @@ class NamespaceNamePropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->appFactory = $this->getMockBuilder( '\SESP\AppFactory' )
+		$this->appFactory = $this->getMockBuilder( AppFactory::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -57,7 +59,7 @@ class NamespaceNamePropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	public function testAddAnnotation( $nsid, $nsname ) {
 		$subject = WikiPage::newFromText( __METHOD__, $nsid );
 
-		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
+		$semanticData = $this->getMockBuilder( SemanticData::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/NamespaceNamePropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/NamespaceNamePropertyAnnotatorTest.php
@@ -3,10 +3,9 @@
 namespace SESP\Tests\PropertyAnnotators;
 
 use SESP\PropertyAnnotators\NamespaceNamePropertyAnnotator;
-use SMW\DIProperty;
-use SMW\DIWikiPage;
-use SMWDIBlob;
-
+use SMW\DataItems\Property;
+use SMW\DataItems\WikiPage;
+use SMW\DataItems\Blob;
 /**
  * @covers \SESP\PropertyAnnotators\NamespacePropertyAnnotator
  * @group semantic-extra-special-properties
@@ -25,7 +24,7 @@ class NamespaceNamePropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->property = new DIProperty( '___NSNAME' );
+		$this->property = new Property( '___NSNAME' );
 	}
 
 	/**
@@ -56,9 +55,9 @@ class NamespaceNamePropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	 * @covers \SESP\PropertyAnnotators\NamespaceNamePropertyAnnotator::addAnnotation
 	 */
 	public function testAddAnnotation( $nsid, $nsname ) {
-		$subject = DIWikiPage::newFromText( __METHOD__, $nsid );
+		$subject = WikiPage::newFromText( __METHOD__, $nsid );
 
-		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -70,7 +69,7 @@ class NamespaceNamePropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'addPropertyObjectValue' )
 			->with(
 				$this->property,
-				new SMWDIBlob( $nsname ) );
+				new Blob( $nsname ) );
 		$annotator = new NamespaceNamePropertyAnnotator(
 			$this->appFactory
 		);

--- a/tests/phpunit/Unit/PropertyAnnotators/NamespaceNamePropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/NamespaceNamePropertyAnnotatorTest.php
@@ -2,12 +2,13 @@
 
 namespace SESP\Tests\PropertyAnnotators;
 
+use SESP\AppFactory;
 use SESP\PropertyAnnotators\NamespaceNamePropertyAnnotator;
+use SMW\DataItems\Blob;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
-use SMW\DataItems\Blob;
 use SMW\DataModel\SemanticData;
-use SESP\AppFactory;
+
 /**
  * @covers \SESP\PropertyAnnotators\NamespacePropertyAnnotator
  * @group semantic-extra-special-properties

--- a/tests/phpunit/Unit/PropertyAnnotators/NamespacePropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/NamespacePropertyAnnotatorTest.php
@@ -6,6 +6,8 @@ use SESP\PropertyAnnotators\NamespacePropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\DataItems\Number;
+use SMW\DataModel\SemanticData;
+use SESP\AppFactory;
 /**
  * @covers \SESP\PropertyAnnotators\NamespacePropertyAnnotator
  * @group semantic-extra-special-properties
@@ -20,7 +22,7 @@ class NamespacePropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->appFactory = $this->getMockBuilder( '\SESP\AppFactory' )
+		$this->appFactory = $this->getMockBuilder( AppFactory::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -57,7 +59,7 @@ class NamespacePropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 		$namespace = NS_USER;
 		$subject = WikiPage::newFromText( __METHOD__, $namespace );
 
-		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
+		$semanticData = $this->getMockBuilder( SemanticData::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/NamespacePropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/NamespacePropertyAnnotatorTest.php
@@ -3,10 +3,9 @@
 namespace SESP\Tests\PropertyAnnotators;
 
 use SESP\PropertyAnnotators\NamespacePropertyAnnotator;
-use SMW\DIProperty;
-use SMW\DIWikiPage;
-use SMWDINumber;
-
+use SMW\DataItems\Property;
+use SMW\DataItems\WikiPage;
+use SMW\DataItems\Number;
 /**
  * @covers \SESP\PropertyAnnotators\NamespacePropertyAnnotator
  * @group semantic-extra-special-properties
@@ -25,7 +24,7 @@ class NamespacePropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->property = new DIProperty( '___NSID' );
+		$this->property = new Property( '___NSID' );
 	}
 
 	/**
@@ -56,9 +55,9 @@ class NamespacePropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	 */
 	public function testAddAnnotation() {
 		$namespace = NS_USER;
-		$subject = DIWikiPage::newFromText( __METHOD__, $namespace );
+		$subject = WikiPage::newFromText( __METHOD__, $namespace );
 
-		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -70,7 +69,7 @@ class NamespacePropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'addPropertyObjectValue' )
 			->with(
 				$this->property,
-				new SMWDINumber( $namespace ) );
+				new Number( $namespace ) );
 		$annotator = new NamespacePropertyAnnotator(
 			$this->appFactory
 		);

--- a/tests/phpunit/Unit/PropertyAnnotators/NamespacePropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/NamespacePropertyAnnotatorTest.php
@@ -2,12 +2,13 @@
 
 namespace SESP\Tests\PropertyAnnotators;
 
+use SESP\AppFactory;
 use SESP\PropertyAnnotators\NamespacePropertyAnnotator;
+use SMW\DataItems\Number;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
-use SMW\DataItems\Number;
 use SMW\DataModel\SemanticData;
-use SESP\AppFactory;
+
 /**
  * @covers \SESP\PropertyAnnotators\NamespacePropertyAnnotator
  * @group semantic-extra-special-properties

--- a/tests/phpunit/Unit/PropertyAnnotators/NullPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/NullPropertyAnnotatorTest.php
@@ -4,6 +4,8 @@ namespace SESP\Tests\PropertyAnnotators;
 
 use SESP\PropertyAnnotators\NullPropertyAnnotator;
 use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+use SESP\AppFactory;
 /**
  * @covers \SESP\PropertyAnnotators\NullPropertyAnnotator
  * @group semantic-extra-special-properties
@@ -21,7 +23,7 @@ class NullPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->appFactory = $this->getMockBuilder( '\SESP\AppFactory' )
+		$this->appFactory = $this->getMockBuilder( AppFactory::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -46,7 +48,7 @@ class NullPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testAddAnnotation() {
-		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
+		$semanticData = $this->getMockBuilder( SemanticData::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/NullPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/NullPropertyAnnotatorTest.php
@@ -2,10 +2,11 @@
 
 namespace SESP\Tests\PropertyAnnotators;
 
+use SESP\AppFactory;
 use SESP\PropertyAnnotators\NullPropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataModel\SemanticData;
-use SESP\AppFactory;
+
 /**
  * @covers \SESP\PropertyAnnotators\NullPropertyAnnotator
  * @group semantic-extra-special-properties

--- a/tests/phpunit/Unit/PropertyAnnotators/NullPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/NullPropertyAnnotatorTest.php
@@ -3,8 +3,7 @@
 namespace SESP\Tests\PropertyAnnotators;
 
 use SESP\PropertyAnnotators\NullPropertyAnnotator;
-use SMW\DIProperty;
-
+use SMW\DataItems\Property;
 /**
  * @covers \SESP\PropertyAnnotators\NullPropertyAnnotator
  * @group semantic-extra-special-properties
@@ -26,7 +25,7 @@ class NullPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->property = new DIProperty( 'Foo' );
+		$this->property = new Property( 'Foo' );
 	}
 
 	public function testCanConstruct() {
@@ -47,7 +46,7 @@ class NullPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testAddAnnotation() {
-		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/PageContributorsPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/PageContributorsPropertyAnnotatorTest.php
@@ -6,9 +6,9 @@ use ArrayIterator;
 use MediaWiki\Permissions\PermissionManager;
 use SESP\AppFactory;
 use SESP\PropertyAnnotators\PageContributorsPropertyAnnotator;
-use SMW\DIProperty;
-use SMW\DIWikiPage;
-use SMW\SemanticData;
+use SMW\DataItems\Property;
+use SMW\DataItems\WikiPage as DIWikiPage;
+use SMW\DataModel\SemanticData;
 use User;
 use WikiPage;
 
@@ -33,7 +33,7 @@ class PageContributorsPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase 
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->property = new DIProperty( '___EUSER' );
+		$this->property = new Property( '___EUSER' );
 	}
 
 	public function testCanConstruct() {

--- a/tests/phpunit/Unit/PropertyAnnotators/PageIDPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/PageIDPropertyAnnotatorTest.php
@@ -4,9 +4,9 @@ namespace SESP\Tests\PropertyAnnotators;
 
 use SESP\AppFactory;
 use SESP\PropertyAnnotators\PageIDPropertyAnnotator;
-use SMW\DIProperty;
-use SMW\DIWikiPage;
-use SMW\SemanticData;
+use SMW\DataItems\Property;
+use SMW\DataItems\WikiPage as DIWikiPage;
+use SMW\DataModel\SemanticData;
 use WikiPage;
 
 /**
@@ -30,7 +30,7 @@ class PageIDPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->property = new DIProperty( '___PAGEID' );
+		$this->property = new Property( '___PAGEID' );
 	}
 
 	public function testCanConstruct() {

--- a/tests/phpunit/Unit/PropertyAnnotators/PageImagesPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/PageImagesPropertyAnnotatorTest.php
@@ -5,10 +5,9 @@ namespace SESP\Tests\PropertyAnnotators;
 use MediaWiki\Title\Title;
 use SESP\AppFactory;
 use SESP\PropertyAnnotators\PageImagesPropertyAnnotator;
-use SMW\DIProperty;
-use SMW\DIWikiPage;
-use SMW\SemanticData;
-
+use SMW\DataItems\Property;
+use SMW\DataItems\WikiPage;
+use SMW\DataModel\SemanticData;
 /**
  * @covers \SESP\PropertyAnnotators\PageImagesPropertyAnnotator
  * @group semantic-extra-special-properties
@@ -30,7 +29,7 @@ class PageImagesPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->property = new DIProperty( '___PAGEIMG' );
+		$this->property = new Property( '___PAGEIMG' );
 	}
 
 	public function testCanConstruct() {
@@ -55,7 +54,7 @@ class PageImagesPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$subject = $this->getMockBuilder( DIWikiPage::class )
+		$subject = $this->getMockBuilder( WikiPage::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -78,7 +77,7 @@ class PageImagesPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 
 		$instance->expects( $this->once() )
 			->method( 'getPageImageTitle' )
-			->willReturn( DIWikiPage::newFromText( __METHOD__ )->getTitle() );
+			->willReturn( WikiPage::newFromText( __METHOD__ )->getTitle() );
 
 		$instance->addAnnotation( $this->property, $semanticData );
 	}

--- a/tests/phpunit/Unit/PropertyAnnotators/PageImagesPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/PageImagesPropertyAnnotatorTest.php
@@ -8,6 +8,7 @@ use SESP\PropertyAnnotators\PageImagesPropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
+
 /**
  * @covers \SESP\PropertyAnnotators\PageImagesPropertyAnnotator
  * @group semantic-extra-special-properties

--- a/tests/phpunit/Unit/PropertyAnnotators/PageLengthPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/PageLengthPropertyAnnotatorTest.php
@@ -6,7 +6,7 @@ use MediaWiki\Title\Title;
 use SESP\AppFactory;
 use SESP\PropertyAnnotators\PageLengthPropertyAnnotator;
 use SMW\DataItems\Property;
-use SMW\DataItems\WikiPage as DIWikiPage;
+use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
 
 /**
@@ -62,7 +62,7 @@ class PageLengthPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getLength' )
 			->willReturn( $length );
 
-		$subject = $this->getMockBuilder( DIWikiPage::class )
+		$subject = $this->getMockBuilder( WikiPage::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/PageLengthPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/PageLengthPropertyAnnotatorTest.php
@@ -4,8 +4,7 @@ namespace SESP\Tests\PropertyAnnotators;
 
 use MediaWiki\Title\Title;
 use SESP\PropertyAnnotators\PageLengthPropertyAnnotator;
-use SMW\DIProperty;
-
+use SMW\DataItems\Property;
 /**
  * @covers \SESP\PropertyAnnotators\PageLengthPropertyAnnotator
  * @group semantic-extra-special-properties
@@ -27,7 +26,7 @@ class PageLengthPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->property = new DIProperty( '___PAGELGTH' );
+		$this->property = new Property( '___PAGELGTH' );
 	}
 
 	public function testCanConstruct() {
@@ -59,7 +58,7 @@ class PageLengthPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getLength' )
 			->willReturn( $length );
 
-		$subject = $this->getMockBuilder( '\SMW\DIWikiPage' )
+		$subject = $this->getMockBuilder( '\SMW\WikiPage' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -67,7 +66,7 @@ class PageLengthPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getTitle' )
 			->willReturn( $title );
 
-		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/PageLengthPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/PageLengthPropertyAnnotatorTest.php
@@ -3,11 +3,12 @@
 namespace SESP\Tests\PropertyAnnotators;
 
 use MediaWiki\Title\Title;
+use SESP\AppFactory;
 use SESP\PropertyAnnotators\PageLengthPropertyAnnotator;
 use SMW\DataItems\Property;
-use SMW\DataModel\SemanticData;
-use SESP\AppFactory;
 use SMW\DataItems\WikiPage as DIWikiPage;
+use SMW\DataModel\SemanticData;
+
 /**
  * @covers \SESP\PropertyAnnotators\PageLengthPropertyAnnotator
  * @group semantic-extra-special-properties

--- a/tests/phpunit/Unit/PropertyAnnotators/PageLengthPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/PageLengthPropertyAnnotatorTest.php
@@ -5,6 +5,9 @@ namespace SESP\Tests\PropertyAnnotators;
 use MediaWiki\Title\Title;
 use SESP\PropertyAnnotators\PageLengthPropertyAnnotator;
 use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+use SESP\AppFactory;
+use SMW\DataItems\WikiPage as DIWikiPage;
 /**
  * @covers \SESP\PropertyAnnotators\PageLengthPropertyAnnotator
  * @group semantic-extra-special-properties
@@ -22,7 +25,7 @@ class PageLengthPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->appFactory = $this->getMockBuilder( '\SESP\AppFactory' )
+		$this->appFactory = $this->getMockBuilder( AppFactory::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -58,7 +61,7 @@ class PageLengthPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getLength' )
 			->willReturn( $length );
 
-		$subject = $this->getMockBuilder( '\SMW\WikiPage' )
+		$subject = $this->getMockBuilder( DIWikiPage::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -66,7 +69,7 @@ class PageLengthPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getTitle' )
 			->willReturn( $title );
 
-		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
+		$semanticData = $this->getMockBuilder( SemanticData::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/PageNumRevisionPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/PageNumRevisionPropertyAnnotatorTest.php
@@ -5,6 +5,10 @@ namespace SESP\Tests\PropertyAnnotators;
 use MediaWiki\Title\Title;
 use SESP\PropertyAnnotators\PageNumRevisionPropertyAnnotator;
 use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+use SESP\AppFactory;
+use SMW\DataItems\WikiPage as DIWikiPage;
+use stdClass;
 /**
  * @covers \SESP\PropertyAnnotators\PageNumRevisionPropertyAnnotator
  * @group semantic-extra-special-properties
@@ -22,7 +26,7 @@ class PageNumRevisionPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->appFactory = $this->getMockBuilder( '\SESP\AppFactory' )
+		$this->appFactory = $this->getMockBuilder( AppFactory::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -62,7 +66,7 @@ class PageNumRevisionPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getArticleID' )
 			->willReturn( 1001 );
 
-		$subject = $this->getMockBuilder( '\SMW\WikiPage' )
+		$subject = $this->getMockBuilder( DIWikiPage::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -70,7 +74,7 @@ class PageNumRevisionPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getTitle' )
 			->willReturn( $title );
 
-		$connection = $this->getMockBuilder( '\stdClass' )
+		$connection = $this->getMockBuilder( stdClass::class )
 			->disableOriginalConstructor()
 			->addMethods( [ 'estimateRowCount' ] )
 			->getMock();
@@ -83,7 +87,7 @@ class PageNumRevisionPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getConnection' )
 			->willReturn( $connection );
 
-		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
+		$semanticData = $this->getMockBuilder( SemanticData::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/PageNumRevisionPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/PageNumRevisionPropertyAnnotatorTest.php
@@ -6,7 +6,7 @@ use MediaWiki\Title\Title;
 use SESP\AppFactory;
 use SESP\PropertyAnnotators\PageNumRevisionPropertyAnnotator;
 use SMW\DataItems\Property;
-use SMW\DataItems\WikiPage as DIWikiPage;
+use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
 use stdClass;
 
@@ -67,7 +67,7 @@ class PageNumRevisionPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getArticleID' )
 			->willReturn( 1001 );
 
-		$subject = $this->getMockBuilder( DIWikiPage::class )
+		$subject = $this->getMockBuilder( WikiPage::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/PageNumRevisionPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/PageNumRevisionPropertyAnnotatorTest.php
@@ -4,8 +4,7 @@ namespace SESP\Tests\PropertyAnnotators;
 
 use MediaWiki\Title\Title;
 use SESP\PropertyAnnotators\PageNumRevisionPropertyAnnotator;
-use SMW\DIProperty;
-
+use SMW\DataItems\Property;
 /**
  * @covers \SESP\PropertyAnnotators\PageNumRevisionPropertyAnnotator
  * @group semantic-extra-special-properties
@@ -27,7 +26,7 @@ class PageNumRevisionPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->property = new DIProperty( '___NREV' );
+		$this->property = new Property( '___NREV' );
 	}
 
 	public function testCanConstruct() {
@@ -63,7 +62,7 @@ class PageNumRevisionPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getArticleID' )
 			->willReturn( 1001 );
 
-		$subject = $this->getMockBuilder( '\SMW\DIWikiPage' )
+		$subject = $this->getMockBuilder( '\SMW\WikiPage' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -84,7 +83,7 @@ class PageNumRevisionPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getConnection' )
 			->willReturn( $connection );
 
-		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/PageNumRevisionPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/PageNumRevisionPropertyAnnotatorTest.php
@@ -3,12 +3,13 @@
 namespace SESP\Tests\PropertyAnnotators;
 
 use MediaWiki\Title\Title;
+use SESP\AppFactory;
 use SESP\PropertyAnnotators\PageNumRevisionPropertyAnnotator;
 use SMW\DataItems\Property;
-use SMW\DataModel\SemanticData;
-use SESP\AppFactory;
 use SMW\DataItems\WikiPage as DIWikiPage;
+use SMW\DataModel\SemanticData;
 use stdClass;
+
 /**
  * @covers \SESP\PropertyAnnotators\PageNumRevisionPropertyAnnotator
  * @group semantic-extra-special-properties

--- a/tests/phpunit/Unit/PropertyAnnotators/PageViewsPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/PageViewsPropertyAnnotatorTest.php
@@ -4,9 +4,9 @@ namespace SESP\Tests\PropertyAnnotators;
 
 use SESP\AppFactory;
 use SESP\PropertyAnnotators\PageViewsPropertyAnnotator;
-use SMW\DIProperty;
-use SMW\DIWikiPage;
-use SMW\SemanticData;
+use SMW\DataItems\Property;
+use SMW\DataItems\WikiPage as DIWikiPage;
+use SMW\DataModel\SemanticData;
 use WikiPage;
 
 /**
@@ -30,7 +30,7 @@ class PageViewsPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->property = new DIProperty( '___VIEWS' );
+		$this->property = new Property( '___VIEWS' );
 	}
 
 	public function testCanConstruct() {

--- a/tests/phpunit/Unit/PropertyAnnotators/RevisionIDPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/RevisionIDPropertyAnnotatorTest.php
@@ -4,9 +4,9 @@ namespace SESP\Tests\PropertyAnnotators;
 
 use SESP\AppFactory;
 use SESP\PropertyAnnotators\RevisionIDPropertyAnnotator;
-use SMW\DIProperty;
-use SMW\DIWikiPage;
-use SMW\SemanticData;
+use SMW\DataItems\Property;
+use SMW\DataItems\WikiPage as DIWikiPage;
+use SMW\DataModel\SemanticData;
 use WikiPage;
 
 /**
@@ -30,7 +30,7 @@ class RevisionIDPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->property = new DIProperty( '___REVID' );
+		$this->property = new Property( '___REVID' );
 	}
 
 	public function testCanConstruct() {

--- a/tests/phpunit/Unit/PropertyAnnotators/ShortUrlPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ShortUrlPropertyAnnotatorTest.php
@@ -2,11 +2,12 @@
 
 namespace SESP\Tests\PropertyAnnotators;
 
+use SESP\AppFactory;
 use SESP\PropertyAnnotators\ShortUrlPropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
-use SESP\AppFactory;
+
 /**
  * @covers \SESP\PropertyAnnotators\ShortUrlPropertyAnnotator
  * @group semantic-extra-special-properties

--- a/tests/phpunit/Unit/PropertyAnnotators/ShortUrlPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ShortUrlPropertyAnnotatorTest.php
@@ -3,9 +3,8 @@
 namespace SESP\Tests\PropertyAnnotators;
 
 use SESP\PropertyAnnotators\ShortUrlPropertyAnnotator;
-use SMW\DIProperty;
-use SMW\DIWikiPage;
-
+use SMW\DataItems\Property;
+use SMW\DataItems\WikiPage;
 /**
  * @covers \SESP\PropertyAnnotators\ShortUrlPropertyAnnotator
  * @group semantic-extra-special-properties
@@ -27,7 +26,7 @@ class ShortUrlPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->property = new DIProperty( '___SHORTURL' );
+		$this->property = new Property( '___SHORTURL' );
 	}
 
 	public function testCanConstruct() {
@@ -55,7 +54,7 @@ class ShortUrlPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			$this->setExpectedException( '\RuntimeException' );
 		}
 
-		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -72,9 +71,9 @@ class ShortUrlPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testAddAnnotation() {
-		$subject = DIWikiPage::newFromText( __METHOD__ );
+		$subject = WikiPage::newFromText( __METHOD__ );
 
-		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/ShortUrlPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ShortUrlPropertyAnnotatorTest.php
@@ -5,6 +5,8 @@ namespace SESP\Tests\PropertyAnnotators;
 use SESP\PropertyAnnotators\ShortUrlPropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
+use SMW\DataModel\SemanticData;
+use SESP\AppFactory;
 /**
  * @covers \SESP\PropertyAnnotators\ShortUrlPropertyAnnotator
  * @group semantic-extra-special-properties
@@ -22,7 +24,7 @@ class ShortUrlPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->appFactory = $this->getMockBuilder( '\SESP\AppFactory' )
+		$this->appFactory = $this->getMockBuilder( AppFactory::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -54,7 +56,7 @@ class ShortUrlPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			$this->setExpectedException( '\RuntimeException' );
 		}
 
-		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
+		$semanticData = $this->getMockBuilder( SemanticData::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -73,7 +75,7 @@ class ShortUrlPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	public function testAddAnnotation() {
 		$subject = WikiPage::newFromText( __METHOD__ );
 
-		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
+		$semanticData = $this->getMockBuilder( SemanticData::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/SubPagePropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/SubPagePropertyAnnotatorTest.php
@@ -3,12 +3,13 @@
 namespace SESP\Tests\PropertyAnnotators;
 
 use MediaWiki\Title\Title;
+use SESP\AppFactory;
 use SESP\PropertyAnnotators\SubPagePropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
-use SMW\DataModel\SemanticData;
-use SESP\AppFactory;
 use SMW\DataItems\WikiPage as DIWikiPage;
+use SMW\DataModel\SemanticData;
+
 /**
  * @covers \SESP\PropertyAnnotators\SubPagePropertyAnnotator
  * @group semantic-extra-special-properties

--- a/tests/phpunit/Unit/PropertyAnnotators/SubPagePropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/SubPagePropertyAnnotatorTest.php
@@ -4,9 +4,8 @@ namespace SESP\Tests\PropertyAnnotators;
 
 use MediaWiki\Title\Title;
 use SESP\PropertyAnnotators\SubPagePropertyAnnotator;
-use SMW\DIProperty;
-use SMW\DIWikiPage;
-
+use SMW\DataItems\Property;
+use SMW\DataItems\WikiPage;
 /**
  * @covers \SESP\PropertyAnnotators\SubPagePropertyAnnotator
  * @group semantic-extra-special-properties
@@ -28,7 +27,7 @@ class SubPagePropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->property = new DIProperty( '___SUBP' );
+		$this->property = new Property( '___SUBP' );
 	}
 
 	public function testCanConstruct() {
@@ -49,7 +48,7 @@ class SubPagePropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testAddAnnotation() {
-		$sub = DIWikiPage::newFromText( __METHOD__ )->getTitle();
+		$sub = WikiPage::newFromText( __METHOD__ )->getTitle();
 
 		$title = $this->getMockBuilder( Title::class )
 			->disableOriginalConstructor()
@@ -59,7 +58,7 @@ class SubPagePropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getSubpages' )
 			->willReturn( [ $sub ] );
 
-		$subject = $this->getMockBuilder( '\SMW\DIWikiPage' )
+		$subject = $this->getMockBuilder( '\SMW\WikiPage' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -67,7 +66,7 @@ class SubPagePropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getTitle' )
 			->willReturn( $title );
 
-		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/SubPagePropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/SubPagePropertyAnnotatorTest.php
@@ -6,6 +6,9 @@ use MediaWiki\Title\Title;
 use SESP\PropertyAnnotators\SubPagePropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
+use SMW\DataModel\SemanticData;
+use SESP\AppFactory;
+use SMW\DataItems\WikiPage as DIWikiPage;
 /**
  * @covers \SESP\PropertyAnnotators\SubPagePropertyAnnotator
  * @group semantic-extra-special-properties
@@ -23,7 +26,7 @@ class SubPagePropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->appFactory = $this->getMockBuilder( '\SESP\AppFactory' )
+		$this->appFactory = $this->getMockBuilder( AppFactory::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -58,7 +61,7 @@ class SubPagePropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getSubpages' )
 			->willReturn( [ $sub ] );
 
-		$subject = $this->getMockBuilder( '\SMW\WikiPage' )
+		$subject = $this->getMockBuilder( DIWikiPage::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -66,7 +69,7 @@ class SubPagePropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getTitle' )
 			->willReturn( $title );
 
-		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
+		$semanticData = $this->getMockBuilder( SemanticData::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/SubPagePropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/SubPagePropertyAnnotatorTest.php
@@ -7,7 +7,6 @@ use SESP\AppFactory;
 use SESP\PropertyAnnotators\SubPagePropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
-use SMW\DataItems\WikiPage as DIWikiPage;
 use SMW\DataModel\SemanticData;
 
 /**
@@ -62,7 +61,7 @@ class SubPagePropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getSubpages' )
 			->willReturn( [ $sub ] );
 
-		$subject = $this->getMockBuilder( DIWikiPage::class )
+		$subject = $this->getMockBuilder( WikiPage::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/TalkPageNumRevisionPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/TalkPageNumRevisionPropertyAnnotatorTest.php
@@ -3,12 +3,13 @@
 namespace SESP\Tests\PropertyAnnotators;
 
 use MediaWiki\Title\Title;
+use SESP\AppFactory;
 use SESP\PropertyAnnotators\TalkPageNumRevisionPropertyAnnotator;
 use SMW\DataItems\Property;
-use SMW\DataModel\SemanticData;
-use SESP\AppFactory;
 use SMW\DataItems\WikiPage as DIWikiPage;
+use SMW\DataModel\SemanticData;
 use stdClass;
+
 /**
  * @covers \SESP\PropertyAnnotators\TalkPageNumRevisionPropertyAnnotator
  * @group semantic-extra-special-properties

--- a/tests/phpunit/Unit/PropertyAnnotators/TalkPageNumRevisionPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/TalkPageNumRevisionPropertyAnnotatorTest.php
@@ -6,7 +6,7 @@ use MediaWiki\Title\Title;
 use SESP\AppFactory;
 use SESP\PropertyAnnotators\TalkPageNumRevisionPropertyAnnotator;
 use SMW\DataItems\Property;
-use SMW\DataItems\WikiPage as DIWikiPage;
+use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
 use stdClass;
 
@@ -75,7 +75,7 @@ class TalkPageNumRevisionPropertyAnnotatorTest extends \PHPUnit\Framework\TestCa
 			->method( 'getTalkPage' )
 			->willReturn( $talkPage );
 
-		$subject = $this->getMockBuilder( DIWikiPage::class )
+		$subject = $this->getMockBuilder( WikiPage::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/TalkPageNumRevisionPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/TalkPageNumRevisionPropertyAnnotatorTest.php
@@ -4,8 +4,7 @@ namespace SESP\Tests\PropertyAnnotators;
 
 use MediaWiki\Title\Title;
 use SESP\PropertyAnnotators\TalkPageNumRevisionPropertyAnnotator;
-use SMW\DIProperty;
-
+use SMW\DataItems\Property;
 /**
  * @covers \SESP\PropertyAnnotators\TalkPageNumRevisionPropertyAnnotator
  * @group semantic-extra-special-properties
@@ -27,7 +26,7 @@ class TalkPageNumRevisionPropertyAnnotatorTest extends \PHPUnit\Framework\TestCa
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->property = new DIProperty( '___NTREV' );
+		$this->property = new Property( '___NTREV' );
 	}
 
 	public function testCanConstruct() {
@@ -71,7 +70,7 @@ class TalkPageNumRevisionPropertyAnnotatorTest extends \PHPUnit\Framework\TestCa
 			->method( 'getTalkPage' )
 			->willReturn( $talkPage );
 
-		$subject = $this->getMockBuilder( '\SMW\DIWikiPage' )
+		$subject = $this->getMockBuilder( '\SMW\WikiPage' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -92,7 +91,7 @@ class TalkPageNumRevisionPropertyAnnotatorTest extends \PHPUnit\Framework\TestCa
 			->method( 'getConnection' )
 			->willReturn( $connection );
 
-		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/TalkPageNumRevisionPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/TalkPageNumRevisionPropertyAnnotatorTest.php
@@ -5,6 +5,10 @@ namespace SESP\Tests\PropertyAnnotators;
 use MediaWiki\Title\Title;
 use SESP\PropertyAnnotators\TalkPageNumRevisionPropertyAnnotator;
 use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+use SESP\AppFactory;
+use SMW\DataItems\WikiPage as DIWikiPage;
+use stdClass;
 /**
  * @covers \SESP\PropertyAnnotators\TalkPageNumRevisionPropertyAnnotator
  * @group semantic-extra-special-properties
@@ -22,7 +26,7 @@ class TalkPageNumRevisionPropertyAnnotatorTest extends \PHPUnit\Framework\TestCa
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->appFactory = $this->getMockBuilder( '\SESP\AppFactory' )
+		$this->appFactory = $this->getMockBuilder( AppFactory::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -70,7 +74,7 @@ class TalkPageNumRevisionPropertyAnnotatorTest extends \PHPUnit\Framework\TestCa
 			->method( 'getTalkPage' )
 			->willReturn( $talkPage );
 
-		$subject = $this->getMockBuilder( '\SMW\WikiPage' )
+		$subject = $this->getMockBuilder( DIWikiPage::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -78,7 +82,7 @@ class TalkPageNumRevisionPropertyAnnotatorTest extends \PHPUnit\Framework\TestCa
 			->method( 'getTitle' )
 			->willReturn( $title );
 
-		$connection = $this->getMockBuilder( '\stdClass' )
+		$connection = $this->getMockBuilder( stdClass::class )
 			->disableOriginalConstructor()
 			->addMethods( [ 'estimateRowCount' ] )
 			->getMock();
@@ -91,7 +95,7 @@ class TalkPageNumRevisionPropertyAnnotatorTest extends \PHPUnit\Framework\TestCa
 			->method( 'getConnection' )
 			->willReturn( $connection );
 
-		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
+		$semanticData = $this->getMockBuilder( SemanticData::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/UserBlockPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/UserBlockPropertyAnnotatorTest.php
@@ -7,10 +7,9 @@ use MediaWiki\Title\Title;
 use MediaWiki\User\User;
 use SESP\AppFactory;
 use SESP\PropertyAnnotators\UserBlockPropertyAnnotator;
-use SMW\DIProperty;
-use SMW\DIWikiPage;
-use SMW\SemanticData;
-
+use SMW\DataItems\Property;
+use SMW\DataItems\WikiPage;
+use SMW\DataModel\SemanticData;
 /**
  * @covers \SESP\PropertyAnnotators\UserBlockPropertyAnnotator
  * @group semantic-extra-special-properties
@@ -32,7 +31,7 @@ class UserBlockPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->property = new DIProperty( '___USERBLOCK' );
+		$this->property = new Property( '___USERBLOCK' );
 	}
 
 	public function testCanConstruct() {
@@ -88,7 +87,7 @@ class UserBlockPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'inNamespace' )
 			->willReturn( true );
 
-		$subject = $this->getMockBuilder( DIWikiPage::class )
+		$subject = $this->getMockBuilder( WikiPage::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/UserBlockPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/UserBlockPropertyAnnotatorTest.php
@@ -10,6 +10,7 @@ use SESP\PropertyAnnotators\UserBlockPropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
+
 /**
  * @covers \SESP\PropertyAnnotators\UserBlockPropertyAnnotator
  * @group semantic-extra-special-properties

--- a/tests/phpunit/Unit/PropertyAnnotators/UserEditCountPerNsPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/UserEditCountPerNsPropertyAnnotatorTest.php
@@ -4,10 +4,10 @@ namespace SESP\Tests\PropertyAnnotators;
 
 use SESP\AppFactory;
 use SESP\PropertyAnnotators\UserEditCountPerNsPropertyAnnotator;
+use SMW\DataItems\Container;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
-use SMW\DataItems\Container;
 use User;
 use Wikimedia\Rdbms\Database;
 use Wikimedia\Rdbms\FakeResultWrapper;

--- a/tests/phpunit/Unit/PropertyAnnotators/UserEditCountPerNsPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/UserEditCountPerNsPropertyAnnotatorTest.php
@@ -4,10 +4,10 @@ namespace SESP\Tests\PropertyAnnotators;
 
 use SESP\AppFactory;
 use SESP\PropertyAnnotators\UserEditCountPerNsPropertyAnnotator;
-use SMW\DIProperty;
-use SMW\DIWikiPage;
-use SMW\SemanticData;
-use SMWDIContainer;
+use SMW\DataItems\Property;
+use SMW\DataItems\WikiPage;
+use SMW\DataModel\SemanticData;
+use SMW\DataItems\Container;
 use User;
 use Wikimedia\Rdbms\Database;
 use Wikimedia\Rdbms\FakeResultWrapper;
@@ -23,7 +23,7 @@ use Wikimedia\Rdbms\FakeResultWrapper;
  */
 class UserEditCountPerNsPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 
-	/** @var DIProperty */
+	/** @var Property */
 	private $property;
 	/** @var AppFactory */
 	private $appFactory;
@@ -35,7 +35,7 @@ class UserEditCountPerNsPropertyAnnotatorTest extends \PHPUnit\Framework\TestCas
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->property = new DIProperty( '___USEREDITCNTNS' );
+		$this->property = new Property( '___USEREDITCNTNS' );
 	}
 
 	public function testIsAnnotatorFor() {
@@ -105,7 +105,7 @@ class UserEditCountPerNsPropertyAnnotatorTest extends \PHPUnit\Framework\TestCas
 	 * @param int $edits Number of edits
 	 */
 	public function testContainer( $ns, $edits ) {
-		$subject = new DIWikiPage( 'Test', NS_USER );
+		$subject = new WikiPage( 'Test', NS_USER );
 
 		$annotator = new UserEditCountPerNsPropertyAnnotator( $this->appFactory );
 		// Expose the private method container().
@@ -114,17 +114,17 @@ class UserEditCountPerNsPropertyAnnotatorTest extends \PHPUnit\Framework\TestCas
 		$method->setAccessible( true );
 		$container = $method->invokeArgs( $annotator, [ $subject, $ns, $edits ] );
 
-		$this->assertInstanceOf( SMWDIContainer::class, $container, 'Container is not an instance of SMWDIContainer' );
+		$this->assertInstanceOf( Container::class, $container, 'Container is not an instance of Container' );
 
 		$data = $container->getSemanticData();
 		$properties = $data->getProperties();
 
 		$this->assertArrayHasKey( '___USEREDITCNTNS_NS', $properties, 'No namespace number in the container' );
-		$nsValue = $data->getPropertyValues( new DIProperty( '___USEREDITCNTNS_NS' ) )[0]->getNumber();
+		$nsValue = $data->getPropertyValues( new Property( '___USEREDITCNTNS_NS' ) )[0]->getNumber();
 		$this->assertEquals( $ns, $nsValue, 'Wrong namespace number' );
 
 		$this->assertArrayHasKey( '___USEREDITCNTNS_CNT', $properties, 'No edit cont in the container' );
-		$editsValue = $data->getPropertyValues( new DIProperty( '___USEREDITCNTNS_CNT' ) )[0]->getNumber();
+		$editsValue = $data->getPropertyValues( new Property( '___USEREDITCNTNS_CNT' ) )[0]->getNumber();
 		$this->assertEquals( $edits, $editsValue, 'Wrong edit count' );
 	}
 
@@ -146,7 +146,7 @@ class UserEditCountPerNsPropertyAnnotatorTest extends \PHPUnit\Framework\TestCas
 	 * @param array $stats
 	 */
 	public function testAddAnnotation( $namespace, $name, $ip, array $stats ) {
-		$subject = new DIWikiPage( $name ?: $ip, $namespace );
+		$subject = new WikiPage( $name ?: $ip, $namespace );
 		$semanticData = new SemanticData( $subject );
 
 		$total = array_sum( $stats );
@@ -196,9 +196,9 @@ class UserEditCountPerNsPropertyAnnotatorTest extends \PHPUnit\Framework\TestCas
 		if ( count( $stats ) > 0 && is_int( $total ) ) {
 			$this->assertArrayHasKey( '___USEREDITCNTNS', $properties, 'No edit count record for the page' );
 
-			$records = $semanticData->getPropertyValues( new DIProperty( '___USEREDITCNTNS' ) );
+			$records = $semanticData->getPropertyValues( new Property( '___USEREDITCNTNS' ) );
 			foreach ( $records as $record ) {
-				$this->assertInstanceOf( DIWikiPage::class, $record );
+				$this->assertInstanceOf( WikiPage::class, $record );
 			}
 			$actual = [];
 			foreach ( $semanticData->getSubSemanticData() as $subSemanticDatum ) {

--- a/tests/phpunit/Unit/PropertyAnnotators/UserEditCountPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/UserEditCountPropertyAnnotatorTest.php
@@ -6,10 +6,9 @@ use MediaWiki\Title\Title;
 use MediaWiki\User\User;
 use SESP\AppFactory;
 use SESP\PropertyAnnotators\UserEditCountPropertyAnnotator;
-use SMW\DIProperty;
-use SMW\DIWikiPage;
-use SMW\SemanticData;
-
+use SMW\DataItems\Property;
+use SMW\DataItems\WikiPage;
+use SMW\DataModel\SemanticData;
 /**
  * @covers \SESP\PropertyAnnotators\UserEditCountPropertyAnnotator
  * @group semantic-extra-special-properties
@@ -31,7 +30,7 @@ class UserEditCountPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->property = new DIProperty( '___USEREDITCNT' );
+		$this->property = new Property( '___USEREDITCNT' );
 	}
 
 	public function testCanConstruct() {
@@ -75,7 +74,7 @@ class UserEditCountPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'inNamespace' )
 			->willReturn( true );
 
-		$subject = $this->getMockBuilder( DIWikiPage::class )
+		$subject = $this->getMockBuilder( WikiPage::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/UserEditCountPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/UserEditCountPropertyAnnotatorTest.php
@@ -9,6 +9,7 @@ use SESP\PropertyAnnotators\UserEditCountPropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
+
 /**
  * @covers \SESP\PropertyAnnotators\UserEditCountPropertyAnnotator
  * @group semantic-extra-special-properties

--- a/tests/phpunit/Unit/PropertyAnnotators/UserGroupPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/UserGroupPropertyAnnotatorTest.php
@@ -5,11 +5,12 @@ namespace SESP\Tests\PropertyAnnotators;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 use MediaWikiIntegrationTestCase;
+use SESP\AppFactory;
 use SESP\PropertyAnnotators\UserGroupPropertyAnnotator;
 use SMW\DataItems\Property;
-use SMW\DataModel\SemanticData;
-use SESP\AppFactory;
 use SMW\DataItems\WikiPage as DIWikiPage;
+use SMW\DataModel\SemanticData;
+
 /**
  * @covers \SESP\PropertyAnnotators\UserGroupPropertyAnnotator
  * @group semantic-extra-special-properties

--- a/tests/phpunit/Unit/PropertyAnnotators/UserGroupPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/UserGroupPropertyAnnotatorTest.php
@@ -7,6 +7,9 @@ use MediaWiki\Title\Title;
 use MediaWikiIntegrationTestCase;
 use SESP\PropertyAnnotators\UserGroupPropertyAnnotator;
 use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+use SESP\AppFactory;
+use SMW\DataItems\WikiPage as DIWikiPage;
 /**
  * @covers \SESP\PropertyAnnotators\UserGroupPropertyAnnotator
  * @group semantic-extra-special-properties
@@ -25,7 +28,7 @@ class UserGroupPropertyAnnotatorTest extends MediaWikiIntegrationTestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->appFactory = $this->getMockBuilder( '\SESP\AppFactory' )
+		$this->appFactory = $this->getMockBuilder( AppFactory::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -77,7 +80,7 @@ class UserGroupPropertyAnnotatorTest extends MediaWikiIntegrationTestCase {
 			->method( 'inNamespace' )
 			->willReturn( true );
 
-		$subject = $this->getMockBuilder( '\SMW\WikiPage' )
+		$subject = $this->getMockBuilder( DIWikiPage::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -85,7 +88,7 @@ class UserGroupPropertyAnnotatorTest extends MediaWikiIntegrationTestCase {
 			->method( 'getTitle' )
 			->willReturn( $title );
 
-		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
+		$semanticData = $this->getMockBuilder( SemanticData::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/UserGroupPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/UserGroupPropertyAnnotatorTest.php
@@ -6,8 +6,7 @@ use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 use MediaWikiIntegrationTestCase;
 use SESP\PropertyAnnotators\UserGroupPropertyAnnotator;
-use SMW\DIProperty;
-
+use SMW\DataItems\Property;
 /**
  * @covers \SESP\PropertyAnnotators\UserGroupPropertyAnnotator
  * @group semantic-extra-special-properties
@@ -30,8 +29,8 @@ class UserGroupPropertyAnnotatorTest extends MediaWikiIntegrationTestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		// Ensure the DIProperty is mocked or initialized correctly
-		$this->property = $this->createMock( DIProperty::class );
+		// Ensure the Property is mocked or initialized correctly
+		$this->property = $this->createMock( Property::class );
 		$this->property->method( 'getLabel' )->willReturn( '___USERGROUP' );
 		$this->property->method( 'getKey' )->willReturn( UserGroupPropertyAnnotator::PROP_ID );
 	}
@@ -78,7 +77,7 @@ class UserGroupPropertyAnnotatorTest extends MediaWikiIntegrationTestCase {
 			->method( 'inNamespace' )
 			->willReturn( true );
 
-		$subject = $this->getMockBuilder( '\SMW\DIWikiPage' )
+		$subject = $this->getMockBuilder( '\SMW\WikiPage' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -86,7 +85,7 @@ class UserGroupPropertyAnnotatorTest extends MediaWikiIntegrationTestCase {
 			->method( 'getTitle' )
 			->willReturn( $title );
 
-		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/UserGroupPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/UserGroupPropertyAnnotatorTest.php
@@ -8,7 +8,7 @@ use MediaWikiIntegrationTestCase;
 use SESP\AppFactory;
 use SESP\PropertyAnnotators\UserGroupPropertyAnnotator;
 use SMW\DataItems\Property;
-use SMW\DataItems\WikiPage as DIWikiPage;
+use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
 
 /**
@@ -81,7 +81,7 @@ class UserGroupPropertyAnnotatorTest extends MediaWikiIntegrationTestCase {
 			->method( 'inNamespace' )
 			->willReturn( true );
 
-		$subject = $this->getMockBuilder( DIWikiPage::class )
+		$subject = $this->getMockBuilder( WikiPage::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/UserRegistrationDatePropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/UserRegistrationDatePropertyAnnotatorTest.php
@@ -4,8 +4,7 @@ namespace SESP\Tests\PropertyAnnotators;
 
 use MediaWiki\Title\Title;
 use SESP\PropertyAnnotators\UserRegistrationDatePropertyAnnotator;
-use SMW\DIProperty;
-
+use SMW\DataItems\Property;
 /**
  * @covers \SESP\PropertyAnnotators\UserRegistrationDatePropertyAnnotator
  * @group semantic-extra-special-properties
@@ -27,7 +26,7 @@ class UserRegistrationDatePropertyAnnotatorTest extends \PHPUnit\Framework\TestC
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->property = new DIProperty( '___USERREG' );
+		$this->property = new Property( '___USERREG' );
 	}
 
 	public function testCanConstruct() {
@@ -68,7 +67,7 @@ class UserRegistrationDatePropertyAnnotatorTest extends \PHPUnit\Framework\TestC
 			->method( 'inNamespace' )
 			->willReturn( true );
 
-		$subject = $this->getMockBuilder( '\SMW\DIWikiPage' )
+		$subject = $this->getMockBuilder( '\SMW\WikiPage' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -76,7 +75,7 @@ class UserRegistrationDatePropertyAnnotatorTest extends \PHPUnit\Framework\TestC
 			->method( 'getTitle' )
 			->willReturn( $title );
 
-		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/UserRegistrationDatePropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/UserRegistrationDatePropertyAnnotatorTest.php
@@ -6,7 +6,7 @@ use MediaWiki\Title\Title;
 use SESP\AppFactory;
 use SESP\PropertyAnnotators\UserRegistrationDatePropertyAnnotator;
 use SMW\DataItems\Property;
-use SMW\DataItems\WikiPage as DIWikiPage;
+use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
 use User;
 
@@ -72,7 +72,7 @@ class UserRegistrationDatePropertyAnnotatorTest extends \PHPUnit\Framework\TestC
 			->method( 'inNamespace' )
 			->willReturn( true );
 
-		$subject = $this->getMockBuilder( DIWikiPage::class )
+		$subject = $this->getMockBuilder( WikiPage::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/UserRegistrationDatePropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/UserRegistrationDatePropertyAnnotatorTest.php
@@ -3,12 +3,13 @@
 namespace SESP\Tests\PropertyAnnotators;
 
 use MediaWiki\Title\Title;
+use SESP\AppFactory;
 use SESP\PropertyAnnotators\UserRegistrationDatePropertyAnnotator;
 use SMW\DataItems\Property;
-use SMW\DataModel\SemanticData;
-use SESP\AppFactory;
 use SMW\DataItems\WikiPage as DIWikiPage;
+use SMW\DataModel\SemanticData;
 use User;
+
 /**
  * @covers \SESP\PropertyAnnotators\UserRegistrationDatePropertyAnnotator
  * @group semantic-extra-special-properties

--- a/tests/phpunit/Unit/PropertyAnnotators/UserRegistrationDatePropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/UserRegistrationDatePropertyAnnotatorTest.php
@@ -5,6 +5,10 @@ namespace SESP\Tests\PropertyAnnotators;
 use MediaWiki\Title\Title;
 use SESP\PropertyAnnotators\UserRegistrationDatePropertyAnnotator;
 use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+use SESP\AppFactory;
+use SMW\DataItems\WikiPage as DIWikiPage;
+use User;
 /**
  * @covers \SESP\PropertyAnnotators\UserRegistrationDatePropertyAnnotator
  * @group semantic-extra-special-properties
@@ -22,7 +26,7 @@ class UserRegistrationDatePropertyAnnotatorTest extends \PHPUnit\Framework\TestC
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->appFactory = $this->getMockBuilder( '\SESP\AppFactory' )
+		$this->appFactory = $this->getMockBuilder( AppFactory::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -47,7 +51,7 @@ class UserRegistrationDatePropertyAnnotatorTest extends \PHPUnit\Framework\TestC
 	}
 
 	public function testAddAnnotation() {
-		$user = $this->getMockBuilder( '\User' )
+		$user = $this->getMockBuilder( User::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -67,7 +71,7 @@ class UserRegistrationDatePropertyAnnotatorTest extends \PHPUnit\Framework\TestC
 			->method( 'inNamespace' )
 			->willReturn( true );
 
-		$subject = $this->getMockBuilder( '\SMW\WikiPage' )
+		$subject = $this->getMockBuilder( DIWikiPage::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -75,7 +79,7 @@ class UserRegistrationDatePropertyAnnotatorTest extends \PHPUnit\Framework\TestC
 			->method( 'getTitle' )
 			->willReturn( $title );
 
-		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
+		$semanticData = $this->getMockBuilder( SemanticData::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/UserRightPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/UserRightPropertyAnnotatorTest.php
@@ -6,6 +6,10 @@ use MediaWiki\Permissions\PermissionManager;
 use MediaWiki\Title\Title;
 use SESP\PropertyAnnotators\UserRightPropertyAnnotator;
 use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+use SESP\AppFactory;
+use SMW\DataItems\WikiPage as DIWikiPage;
+use User;
 /**
  * @covers \SESP\PropertyAnnotators\UserRightPropertyAnnotator
  * @group semantic-extra-special-properties
@@ -23,7 +27,7 @@ class UserRightPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->appFactory = $this->getMockBuilder( '\SESP\AppFactory' )
+		$this->appFactory = $this->getMockBuilder( AppFactory::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -51,7 +55,7 @@ class UserRightPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	 * @dataProvider rightsProvider
 	 */
 	public function testAddAnnotation( $rights, $expected ) {
-		$user = $this->getMockBuilder( '\User' )
+		$user = $this->getMockBuilder( User::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -67,7 +71,7 @@ class UserRightPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'inNamespace' )
 			->willReturn( true );
 
-		$subject = $this->getMockBuilder( '\SMW\WikiPage' )
+		$subject = $this->getMockBuilder( DIWikiPage::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -75,7 +79,7 @@ class UserRightPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getTitle' )
 			->willReturn( $title );
 
-		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
+		$semanticData = $this->getMockBuilder( SemanticData::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/UserRightPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/UserRightPropertyAnnotatorTest.php
@@ -7,7 +7,7 @@ use MediaWiki\Title\Title;
 use SESP\AppFactory;
 use SESP\PropertyAnnotators\UserRightPropertyAnnotator;
 use SMW\DataItems\Property;
-use SMW\DataItems\WikiPage as DIWikiPage;
+use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
 use User;
 
@@ -72,7 +72,7 @@ class UserRightPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'inNamespace' )
 			->willReturn( true );
 
-		$subject = $this->getMockBuilder( DIWikiPage::class )
+		$subject = $this->getMockBuilder( WikiPage::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/UserRightPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/UserRightPropertyAnnotatorTest.php
@@ -5,8 +5,7 @@ namespace SESP\Tests\PropertyAnnotators;
 use MediaWiki\Permissions\PermissionManager;
 use MediaWiki\Title\Title;
 use SESP\PropertyAnnotators\UserRightPropertyAnnotator;
-use SMW\DIProperty;
-
+use SMW\DataItems\Property;
 /**
  * @covers \SESP\PropertyAnnotators\UserRightPropertyAnnotator
  * @group semantic-extra-special-properties
@@ -28,7 +27,7 @@ class UserRightPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->property = new DIProperty( '___USERRIGHT' );
+		$this->property = new Property( '___USERRIGHT' );
 	}
 
 	public function testCanConstruct() {
@@ -68,7 +67,7 @@ class UserRightPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'inNamespace' )
 			->willReturn( true );
 
-		$subject = $this->getMockBuilder( '\SMW\DIWikiPage' )
+		$subject = $this->getMockBuilder( '\SMW\WikiPage' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -76,7 +75,7 @@ class UserRightPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getTitle' )
 			->willReturn( $title );
 
-		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+		$semanticData = $this->getMockBuilder( '\SMW\DataModel\SemanticData' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/PropertyAnnotators/UserRightPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/UserRightPropertyAnnotatorTest.php
@@ -4,12 +4,13 @@ namespace SESP\Tests\PropertyAnnotators;
 
 use MediaWiki\Permissions\PermissionManager;
 use MediaWiki\Title\Title;
+use SESP\AppFactory;
 use SESP\PropertyAnnotators\UserRightPropertyAnnotator;
 use SMW\DataItems\Property;
-use SMW\DataModel\SemanticData;
-use SESP\AppFactory;
 use SMW\DataItems\WikiPage as DIWikiPage;
+use SMW\DataModel\SemanticData;
 use User;
+
 /**
  * @covers \SESP\PropertyAnnotators\UserRightPropertyAnnotator
  * @group semantic-extra-special-properties

--- a/tests/phpunit/Unit/PropertyDefinitionsTest.php
+++ b/tests/phpunit/Unit/PropertyDefinitionsTest.php
@@ -2,8 +2,8 @@
 
 namespace SESP\Tests;
 
-use SESP\PropertyDefinitions;
 use SESP\LabelFetcher;
+use SESP\PropertyDefinitions;
 
 /**
  * @covers \SESP\PropertyDefinitions

--- a/tests/phpunit/Unit/PropertyDefinitionsTest.php
+++ b/tests/phpunit/Unit/PropertyDefinitionsTest.php
@@ -3,6 +3,7 @@
 namespace SESP\Tests;
 
 use SESP\PropertyDefinitions;
+use SESP\LabelFetcher;
 
 /**
  * @covers \SESP\PropertyDefinitions
@@ -20,7 +21,7 @@ class PropertyDefinitionsTest extends \PHPUnit\Framework\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->labelFetcher = $this->getMockBuilder( '\SESP\LabelFetcher' )
+		$this->labelFetcher = $this->getMockBuilder( LabelFetcher::class )
 			->disableOriginalConstructor()
 			->getMock();
 	}

--- a/tests/phpunit/Unit/PropertyRegistryTest.php
+++ b/tests/phpunit/Unit/PropertyRegistryTest.php
@@ -89,7 +89,7 @@ class PropertyRegistryTest extends \PHPUnit\Framework\TestCase {
 			->method( 'registerPropertyAliasByMsgKey' );
 
 		$propertyRegistry->expects( $this->once() )
-			->method( 'registerPropertyDescriptionMsgKeyById' );
+			->method( 'registerPropertyDescriptionByMsgKey' );
 
 		$instance = new PropertyRegistry(
 			$this->appFactory
@@ -133,7 +133,7 @@ class PropertyRegistryTest extends \PHPUnit\Framework\TestCase {
 			->method( 'registerPropertyAliasByMsgKey' );
 
 		$propertyRegistry->expects( $this->once() )
-			->method( 'registerPropertyDescriptionMsgKeyById' );
+			->method( 'registerPropertyDescriptionByMsgKey' );
 
 		$instance = new PropertyRegistry(
 			$this->appFactory

--- a/tests/phpunit/Unit/PropertyRegistryTest.php
+++ b/tests/phpunit/Unit/PropertyRegistryTest.php
@@ -2,9 +2,9 @@
 
 namespace SESP\Tests;
 
-use SESP\PropertyRegistry;
 use SESP\AppFactory;
 use SESP\PropertyDefinitions;
+use SESP\PropertyRegistry;
 use SMW\PropertyRegistry as Registry;
 
 /**

--- a/tests/phpunit/Unit/PropertyRegistryTest.php
+++ b/tests/phpunit/Unit/PropertyRegistryTest.php
@@ -3,6 +3,9 @@
 namespace SESP\Tests;
 
 use SESP\PropertyRegistry;
+use SESP\AppFactory;
+use SESP\PropertyDefinitions;
+use SMW\PropertyRegistry as Registry;
 
 /**
  * @covers \SESP\PropertyRegistry
@@ -20,7 +23,7 @@ class PropertyRegistryTest extends \PHPUnit\Framework\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->appFactory = $this->getMockBuilder( '\SESP\AppFactory' )
+		$this->appFactory = $this->getMockBuilder( AppFactory::class )
 			->disableOriginalConstructor()
 			->getMock();
 	}
@@ -33,7 +36,7 @@ class PropertyRegistryTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testregisterEmptyDefinition() {
-		$propertyDefinitions = $this->getMockBuilder( '\SESP\PropertyDefinitions' )
+		$propertyDefinitions = $this->getMockBuilder( PropertyDefinitions::class )
 			->disableOriginalConstructor()
 			->onlyMethods( [ 'getLabels' ] )
 			->getMock();
@@ -46,7 +49,7 @@ class PropertyRegistryTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getPropertyDefinitions' )
 			->willReturn( $propertyDefinitions );
 
-		$propertyRegistry = $this->getMockBuilder( '\SMW\PropertyRegistry' )
+		$propertyRegistry = $this->getMockBuilder( Registry::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -62,7 +65,7 @@ class PropertyRegistryTest extends \PHPUnit\Framework\TestCase {
 			'SOFTWARE' => [ 'id' => 'Foo', 'type' => '_txt', 'label' => 'Foo' ] ]
 		];
 
-		$propertyDefinitions = $this->getMockBuilder( '\SESP\PropertyDefinitions' )
+		$propertyDefinitions = $this->getMockBuilder( PropertyDefinitions::class )
 			->disableOriginalConstructor()
 			->onlyMethods( [ 'getLabels', 'getLabel' ] )
 			->getMock();
@@ -75,7 +78,7 @@ class PropertyRegistryTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getPropertyDefinitions' )
 			->willReturn( $propertyDefinitions );
 
-		$propertyRegistry = $this->getMockBuilder( '\SMW\PropertyRegistry' )
+		$propertyRegistry = $this->getMockBuilder( Registry::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -106,7 +109,7 @@ class PropertyRegistryTest extends \PHPUnit\Framework\TestCase {
 			'label' => 'SomeCustomProperty',
 		];
 
-		$propertyDefinitions = $this->getMockBuilder( '\SESP\PropertyDefinitions' )
+		$propertyDefinitions = $this->getMockBuilder( PropertyDefinitions::class )
 			->disableOriginalConstructor()
 			->onlyMethods( [ 'getLabels', 'getLabel' ] )
 			->getMock();
@@ -119,7 +122,7 @@ class PropertyRegistryTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getPropertyDefinitions' )
 			->willReturn( $propertyDefinitions );
 
-		$propertyRegistry = $this->getMockBuilder( '\SMW\PropertyRegistry' )
+		$propertyRegistry = $this->getMockBuilder( Registry::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -151,7 +154,7 @@ class PropertyRegistryTest extends \PHPUnit\Framework\TestCase {
 		$this->appFactory->expects( $this->never() )
 			->method( 'getPropertyDefinitions' );
 
-		$propertyRegistry = $this->getMockBuilder( '\SMW\PropertyRegistry' )
+		$propertyRegistry = $this->getMockBuilder( Registry::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -166,7 +169,7 @@ class PropertyRegistryTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testRegisterAsFixedPropertiesEnabled() {
-		$propertyDefinitions = $this->getMockBuilder( '\SESP\PropertyDefinitions' )
+		$propertyDefinitions = $this->getMockBuilder( PropertyDefinitions::class )
 			->disableOriginalConstructor()
 			->onlyMethods( [] )
 			->getMock();


### PR DESCRIPTION
## Summary

- Bumps the extension baseline to **7.0.0-alpha**, raising the required SMW major to **>= 7.0** so only one SMW major needs to be supported (mirrors how Semantic Scribunto is versioned).
- Aligns PHP requirement (`composer.json`) with the PHP floor implied by MediaWiki 1.43 (`>=8.1`), updates the dev-master branch alias to `7.x-dev` (matching SMW core), updates README + CI matrix + Makefile defaults.
- Migrates off SMW 7's removed and deprecated APIs:
  - **Removed (would fatal under SMW 7):** `PropertyRegistry::registerPropertyDescriptionMsgKeyById` -> `registerPropertyDescriptionByMsgKey`.
  - **Deprecated class aliases** (still resolve in 7.x via `class_alias`, but scheduled for removal): `SMW\SemanticData`, `SMW\DIProperty`, `SMW\DIWikiPage`, `SMWDataItem`, `SMWDIBlob`, `SMWDIContainer`, `SMWDINumber`, `SMWDITime`, `SMWDIUri`. All imports updated to `SMW\DataModel\*` / `SMW\DataItems\*` and short identifiers renamed throughout (`DIProperty` -> `Property`, etc.). Five tests that also import MediaWiki core's `\WikiPage` keep the SMW data item as `... as DIWikiPage` (matches SMW core's own disambiguation in `DataUpdater.php`).
  - FQN strings in PHPUnit `getMockBuilder()` calls updated to canonical paths.

Cross-referenced against [`docs/releasenotes/RELEASE-NOTES-7.0.0.md`](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/releasenotes/RELEASE-NOTES-7.0.0.md) in SMW. Confirmed clean:

- SESP uses MediaWiki's `IDatabase` directly (not SMW's removed `Connection\Database` DML wrappers).
- Modern hook names already in use (`SMW::Store::BeforeDataUpdateComplete`, `SMW::SQLStore::AddCustomFixedPropertyTables`).
- No usage of `ApplicationFactory`, `Options::getOptions()`, `Property::setPropertyTypeId()`, etc.

## Test plan

- [x] CI passes against the new matrix (MW 1.43/1.44/1.45 x SMW dev-master)
- [x] PHP lint passes (verified locally)
- [x] Local run of the test suite against SMW dev-master (not yet executed in this PR)
- [x] Smoke test installation against a live MW 1.43 + SMW dev-master wiki

## Notes for reviewer

- The README install constraint `~7.0` won't actually resolve for end users until SMW 7.0.0 stable ships (Composer's default `minimum-stability: stable` excludes the alpha). Same situation as SMW core's own alpha.
- The CI matrix has two duplicate `MW 1.43 + SMW dev-master + PHP 8.1` rows that differ only in `coverage:`. Original purpose was "stable SMW vs dev-master SMW" split; once SMW 7.0.0 stable lands, one row can pin to it.