### PR TITLE
Migrate MW global imports to MediaWiki/Wikimedia namespaces

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -2,7 +2,7 @@
 
 namespace SESP;
 
-use GlobalVarConfig;
+use MediaWiki\Config\GlobalVarConfig;
 
 class Config extends GlobalVarConfig {
 

--- a/src/DatabaseLogReader.php
+++ b/src/DatabaseLogReader.php
@@ -6,7 +6,7 @@ use ArrayIterator;
 use DatabaseLogEntry;
 use MediaWiki\Title\Title;
 use MediaWiki\User\User;
-use MWTimestamp;
+use MediaWiki\Utils\MWTimestamp;
 use Wikimedia\Rdbms\Database;
 
 class DatabaseLogReader {

--- a/src/PropertyAnnotators/ApprovedDatePropertyAnnotator.php
+++ b/src/PropertyAnnotators/ApprovedDatePropertyAnnotator.php
@@ -2,7 +2,7 @@
 
 namespace SESP\PropertyAnnotators;
 
-use MWTimestamp;
+use MediaWiki\Utils\MWTimestamp;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
 use SMW\DataItems\Property;

--- a/src/PropertyAnnotators/ApprovedStatusPropertyAnnotator.php
+++ b/src/PropertyAnnotators/ApprovedStatusPropertyAnnotator.php
@@ -3,12 +3,12 @@
 namespace SESP\PropertyAnnotators;
 
 use ApprovedRevs;
-use IDBAccessObject;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
 use SMW\DataItems\Blob as DIString;
 use SMW\DataItems\Property;
 use SMW\DataModel\SemanticData;
+use Wikimedia\Rdbms\IDBAccessObject;
 
 /**
  * @private

--- a/src/PropertyAnnotators/NamespaceNamePropertyAnnotator.php
+++ b/src/PropertyAnnotators/NamespaceNamePropertyAnnotator.php
@@ -2,8 +2,8 @@
 
 namespace SESP\PropertyAnnotators;
 
+use MediaWiki\Context\RequestContext;
 use MediaWiki\MediaWikiServices;
-use RequestContext;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
 use SMW\DataItems\Blob;

--- a/src/PropertyAnnotators/UserBlockPropertyAnnotator.php
+++ b/src/PropertyAnnotators/UserBlockPropertyAnnotator.php
@@ -2,12 +2,12 @@
 
 namespace SESP\PropertyAnnotators;
 
+use MediaWiki\User\User;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
 use SMW\DataItems\Blob;
 use SMW\DataItems\Property;
 use SMW\DataModel\SemanticData;
-use User;
 
 /**
  * @private

--- a/src/PropertyAnnotators/UserEditCountPerNsPropertyAnnotator.php
+++ b/src/PropertyAnnotators/UserEditCountPerNsPropertyAnnotator.php
@@ -2,6 +2,7 @@
 
 namespace SESP\PropertyAnnotators;
 
+use MediaWiki\User\User;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
 use SMW\DataItems\Container;
@@ -11,7 +12,6 @@ use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\ContainerSemanticData;
 use SMW\DataModel\SemanticData;
-use User;
 use Wikimedia\IPUtils;
 
 /**

--- a/src/PropertyAnnotators/UserEditCountPropertyAnnotator.php
+++ b/src/PropertyAnnotators/UserEditCountPropertyAnnotator.php
@@ -2,13 +2,13 @@
 
 namespace SESP\PropertyAnnotators;
 
+use MediaWiki\User\User;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
 use SMW\DataItems\DataItem;
 use SMW\DataItems\Number;
 use SMW\DataItems\Property;
 use SMW\DataModel\SemanticData;
-use User;
 
 /**
  * @private

--- a/src/PropertyAnnotators/UserGroupPropertyAnnotator.php
+++ b/src/PropertyAnnotators/UserGroupPropertyAnnotator.php
@@ -3,12 +3,12 @@
 namespace SESP\PropertyAnnotators;
 
 use MediaWiki\MediaWikiServices;
+use MediaWiki\User\User;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
 use SMW\DataItems\Blob;
 use SMW\DataItems\Property;
 use SMW\DataModel\SemanticData;
-use User;
 
 /**
  * @private

--- a/src/PropertyAnnotators/UserRegistrationDatePropertyAnnotator.php
+++ b/src/PropertyAnnotators/UserRegistrationDatePropertyAnnotator.php
@@ -2,13 +2,13 @@
 
 namespace SESP\PropertyAnnotators;
 
+use MediaWiki\User\User;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
 use SMW\DataItems\DataItem;
 use SMW\DataItems\Property;
 use SMW\DataItems\Time;
 use SMW\DataModel\SemanticData;
-use User;
 
 /**
  * @private

--- a/src/PropertyAnnotators/UserRightPropertyAnnotator.php
+++ b/src/PropertyAnnotators/UserRightPropertyAnnotator.php
@@ -4,12 +4,12 @@ namespace SESP\PropertyAnnotators;
 
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Permissions\PermissionManager;
+use MediaWiki\User\User;
 use SESP\AppFactory;
 use SESP\PropertyAnnotator;
 use SMW\DataItems\Blob;
 use SMW\DataItems\Property;
 use SMW\DataModel\SemanticData;
-use User;
 
 /**
  * @private

--- a/tests/phpunit/Unit/PropertyAnnotators/ApprovedByPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ApprovedByPropertyAnnotatorTest.php
@@ -2,12 +2,12 @@
 
 namespace SESP\Tests\PropertyAnnotators;
 
+use MediaWiki\User\User;
 use SESP\AppFactory;
 use SESP\PropertyAnnotators\ApprovedByPropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
-use User;
 
 /**
  * @covers \SESP\PropertyAnnotators\ApprovedByPropertyAnnotator

--- a/tests/phpunit/Unit/PropertyAnnotators/ApprovedDatePropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ApprovedDatePropertyAnnotatorTest.php
@@ -2,7 +2,7 @@
 
 namespace SESP\Tests\PropertyAnnotators;
 
-use MWTimestamp;
+use MediaWiki\Utils\MWTimestamp;
 use SESP\AppFactory;
 use SESP\PropertyAnnotators\ApprovedDatePropertyAnnotator;
 use SMW\DataItems\Property;

--- a/tests/phpunit/Unit/PropertyAnnotators/CreatorPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/CreatorPropertyAnnotatorTest.php
@@ -2,12 +2,12 @@
 
 namespace SESP\Tests\PropertyAnnotators;
 
+use MediaWiki\User\User;
 use SESP\AppFactory;
 use SESP\PropertyAnnotators\CreatorPropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage as DIWikiPage;
 use SMW\DataModel\SemanticData;
-use User;
 use WikiPage;
 
 /**

--- a/tests/phpunit/Unit/PropertyAnnotators/PageContributorsPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/PageContributorsPropertyAnnotatorTest.php
@@ -4,12 +4,12 @@ namespace SESP\Tests\PropertyAnnotators;
 
 use ArrayIterator;
 use MediaWiki\Permissions\PermissionManager;
+use MediaWiki\User\User;
 use SESP\AppFactory;
 use SESP\PropertyAnnotators\PageContributorsPropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage as DIWikiPage;
 use SMW\DataModel\SemanticData;
-use User;
 use WikiPage;
 
 /**

--- a/tests/phpunit/Unit/PropertyAnnotators/UserEditCountPerNsPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/UserEditCountPerNsPropertyAnnotatorTest.php
@@ -2,13 +2,13 @@
 
 namespace SESP\Tests\PropertyAnnotators;
 
+use MediaWiki\User\User;
 use SESP\AppFactory;
 use SESP\PropertyAnnotators\UserEditCountPerNsPropertyAnnotator;
 use SMW\DataItems\Container;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
-use User;
 use Wikimedia\Rdbms\Database;
 use Wikimedia\Rdbms\FakeResultWrapper;
 

--- a/tests/phpunit/Unit/PropertyAnnotators/UserRegistrationDatePropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/UserRegistrationDatePropertyAnnotatorTest.php
@@ -3,12 +3,12 @@
 namespace SESP\Tests\PropertyAnnotators;
 
 use MediaWiki\Title\Title;
+use MediaWiki\User\User;
 use SESP\AppFactory;
 use SESP\PropertyAnnotators\UserRegistrationDatePropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage as DIWikiPage;
 use SMW\DataModel\SemanticData;
-use User;
 
 /**
  * @covers \SESP\PropertyAnnotators\UserRegistrationDatePropertyAnnotator

--- a/tests/phpunit/Unit/PropertyAnnotators/UserRightPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/UserRightPropertyAnnotatorTest.php
@@ -4,12 +4,12 @@ namespace SESP\Tests\PropertyAnnotators;
 
 use MediaWiki\Permissions\PermissionManager;
 use MediaWiki\Title\Title;
+use MediaWiki\User\User;
 use SESP\AppFactory;
 use SESP\PropertyAnnotators\UserRightPropertyAnnotator;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage as DIWikiPage;
 use SMW\DataModel\SemanticData;
-use User;
 
 /**
  * @covers \SESP\PropertyAnnotators\UserRightPropertyAnnotator


### PR DESCRIPTION
**Stacked on top of #267** (the SMW 7 compat PR). Base set to `smw-7-compat`. Merge order: #267 first, then this.

## Summary

MediaWiki 1.43's `autoload.php` registers a namespaced equivalent for several legacy global classes (both keys map to the same source file). Migrates SESP's `use` statements to the canonical namespaced path. Pure substitution — class names are identical between the two forms, so no body changes.

| Before | After |
|---|---|
| `use User;` | `use MediaWiki\User\User;` |
| `use MWTimestamp;` | `use MediaWiki\Utils\MWTimestamp;` |
| `use RequestContext;` | `use MediaWiki\Context\RequestContext;` |
| `use IDBAccessObject;` | `use Wikimedia\Rdbms\IDBAccessObject;` |
| `use GlobalVarConfig;` | `use MediaWiki\Config\GlobalVarConfig;` |

Aligns with the partial migration SESP already had — `Title`, `MediaWikiServices`, `PermissionManager`, `DatabaseBlock`, and several others were already imported via their namespaced form.

**Reference:** https://github.com/wikimedia/mediawiki/blob/REL1_43/autoload.php

## Out of scope (no namespaced alias in MW 1.43)

`WikiPage`, `WikiFilePage`, `File`, `FormatMetadata`, `DatabaseLogEntry`, `MediaWikiIntegrationTestCase` — `autoload.php` registers only the global name. PHP SPL globals (`ArrayIterator`, `Iterator`, `InvalidArgumentException`, etc.) and the third-party `ApprovedRevs` global are also unchanged.

## Test plan

- [x] All 275 tests / 588 assertions pass against MW 1.43 + SMW dev-master + PHP 8.1 (local dev container)
- [x] PHP lint clean
- [x] phpcs clean