### PR TITLE
Make Codecov project/patch status checks informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,12 @@
 fixes:
   - "/var/www/html/extensions/SemanticExtraSpecialProperties/::"
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+        removed_code_behavior: adjust_base
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
Codecov was using its default status checks (project target=auto threshold=0%, patch target=auto), so any coverage drop, even -0.01%, and any low diff-coverage patch turned the whole CI red. Coverage is not used to gate merges, so this signal was pure noise.  Set both the project and patch statuses to informational: true.

Codecov still posts the PR comment with coverage deltas, but the checks always report success instead of failing CI. Also set removed_code_behavior: adjust_base so PRs that delete untested code are not scored as coverage regressions.
