### PR TITLE
Fix fatal: ServicesFactory::getMediaWikiLogger() removed in SMW 7.0

### DIFF
--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -2,6 +2,7 @@
 
 namespace SESP;
 
+use MediaWiki\Logger\LoggerFactory;
 use MediaWiki\MediaWikiServices;
 use SMW\PropertyRegistry as Registry;
 use SMW\Services\ServicesFactory;
@@ -135,7 +136,7 @@ class HookRegistry {
 		);
 
 		$appFactory->setLogger(
-			$servicesFactory->getMediaWikiLogger( 'sesp' )
+			LoggerFactory::getInstance( 'sesp' )
 		);
 
 		$propertyRegistry = new PropertyRegistry(


### PR DESCRIPTION
## Problem

SMW 7.0 removed `ServicesFactory::getMediaWikiLogger()` (along with the internal `SMW\Utils\Logger` wrapper) in favour of resolving PSR-3 loggers directly via `MediaWiki\Logger\LoggerFactory`. `HookRegistry::registerCallbackHandlers()` still called the removed method:

```
Error: Call to undefined method SMW\Services\ServicesFactory::getMediaWikiLogger()
  from src/HookRegistry.php(138)
```

Because `extension.json` requires SMW ≥ 7.0, this fatal fires during `SetupAfterCache` on every install — including under maintenance scripts such as `runJobs.php`.

## Fix

Resolve the logger directly through `MediaWiki\Logger\LoggerFactory::getInstance( 'sesp' )`, mirroring how SMW migrated its own callsites. The `'sesp'` log channel is preserved.

The removed wrapper added two behaviours: a role filter (inert at `ROLE_DEVELOPER`, which is how it was always instantiated in production) and a context-value transform (rounding `procTime`/`time` floats, JSON-encoding array context). Neither applies to SESP — both logger callsites (`ExtraPropertyAnnotator`, `LocalPropertyAnnotator`) log a pre-formatted message string with no context array — so the change is behaviour-preserving.

## Testing

The existing `HookRegistryTest::testCanConstruct` / `testRegister` construct a real `HookRegistry`, so they exercise this code path; against SMW 7.0 they reproduce the fatal before this change. CI runs them against the required SMW version.