### PR TITLE
Use a per-MW MariaDB LTS matrix and bump action majors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
             approved_revs_version: 2.1
             php_version: 8.1
             database_type: mysql
-            database_image: "mysql:8"
+            database_image: "mariadb:10.11"
             coverage: false
             experimental: false
           - mediawiki_version: '1.43'
@@ -29,7 +29,7 @@ jobs:
             approved_revs_version: 2.1
             php_version: 8.1
             database_type: mysql
-            database_image: "mysql:8"
+            database_image: "mariadb:11.4"
             coverage: true
             experimental: false
           - mediawiki_version: '1.44'
@@ -37,7 +37,7 @@ jobs:
             approved_revs_version: master
             php_version: 8.2
             database_type: mysql
-            database_image: "mariadb:11.2"
+            database_image: "mariadb:11.8"
             coverage: false
             experimental: false
           - mediawiki_version: '1.45'
@@ -45,7 +45,7 @@ jobs:
             approved_revs_version: master
             php_version: 8.3
             database_type: mysql
-            database_image: "mariadb:11.2"
+            database_image: "mariadb:12.3"
             coverage: false
             experimental: false
 
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
                    
@@ -79,7 +79,7 @@ jobs:
         run: make destroy
 
       - name: Upload code coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/php/coverage.xml


### PR DESCRIPTION
## Summary

Modernise the CI database matrix and action majors:

- **Per-MW MariaDB LTS spread.** Each MediaWiki row now runs against a distinct currently-supported MariaDB LTS — `1.43` → `mariadb:10.11`, `1.43` (coverage) → `mariadb:11.4`, `1.44` → `mariadb:11.8`, `1.45` → `mariadb:12.3` — replacing the end-of-life `mysql:8` and `mariadb:11.2` images.
- **Latest action majors.** `actions/checkout@v4` → `@v6`, `codecov/codecov-action@v4` → `@v6`.

The `approved_revs_version` matrix dimension and the rest of the workflow are unchanged.
