### PR TITLE
Remove redundant autoloader configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,11 +58,6 @@
 			"dev-master": "7.x-dev"
 		}
 	},
-	"autoload": {
-		"psr-4": {
-			"SESP\\": "src/"
-		}
-	},
 	"config": {
 		"process-timeout": 0,
 		"allow-plugins": {

--- a/extension.json
+++ b/extension.json
@@ -78,6 +78,5 @@
 	"Hooks": {
 		"SetupAfterCache": "SESP\\Hook::onSetupAfterCache"
 	},
-	"load_composer_autoloader": true,
 	"manifest_version": 2
 }


### PR DESCRIPTION
## What

Removes two pieces of autoloader configuration that are redundant for this extension:

- the `autoload` block (`psr-4`: `SESP\` → `src/`) in `composer.json`
- the `load_composer_autoloader` flag in `extension.json`

## Why

Class loading is already fully handled by the `AutoloadNamespaces` entry in `extension.json`:

```json
"AutoloadNamespaces": { "SESP\\": "src/" }
```

This maps the **entire** `SESP\` runtime namespace to `src/` and is registered by MediaWiki's own PSR-4 autoloader, independently of Composer (it works even with an empty `vendor/`).

Given that:

- The `composer.json` `autoload` block just duplicates that same `SESP\` → `src/` map. Its only consumer is the root project's Composer autoloader on a `composer require` install — but `SESP\` classes resolve via `AutoloadNamespaces` after `wfLoadExtension`, and nothing references them earlier.
- The extension declares **no runtime Composer dependencies** (`require` is only `php` and `composer/installers`, a Composer-time plugin). So `load_composer_autoloader` only ever caused MediaWiki to load the extension's own `vendor/autoload.php`, which in turn only re-registered the same `SESP\` map.

This also aligns SESP with sibling SMW extensions that already rely solely on `AutoloadNamespaces` (e.g. SemanticMediaWiki core, SemanticScribunto, SemanticMetaTags, SemanticImageCaption ship with no `composer.json` `autoload` block).

## Caveat for reviewers

This is safe **because `AutoloadNamespaces` covers the full `SESP\` namespace**. Two things would change that:

1. If the extension ever gains a real runtime Composer dependency that must be loaded from its own `vendor/`, `load_composer_autoloader` would need to be restored.
2. If part of the runtime namespace were ever moved outside the `AutoloadNamespaces`-covered path (as SemanticResultFormats does with its `SRF\` namespace), the `composer.json` `autoload` block would become load-bearing again.

Neither applies today.

## Testing

`composer test` run with MediaWiki booted and both attributes removed:

- `parallel-lint`: no syntax errors (76 files)
- `phpcs -ps`: clean (no errors, no warnings)
- `phpunit`: **OK (275 tests, 588 assertions)** — every `SESP\` class (AppFactory, HookRegistry, all PropertyAnnotators) resolved via `AutoloadNamespaces` alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)