### PR TITLE
Add integrity test for property-group schema files

### DIFF
--- a/tests/phpunit/Integration/GroupSchemaFileIntegrityTest.php
+++ b/tests/phpunit/Integration/GroupSchemaFileIntegrityTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace SESP\Tests\Integration;
+
+use SMW\Schema\SchemaFactory;
+
+/**
+ * @group semantic-extra-special-properties
+ * @group medium
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+class GroupSchemaFileIntegrityTest extends \PHPUnit\Framework\TestCase {
+
+	/**
+	 * Every property-group schema file referenced by the import manifest must
+	 * pass Semantic MediaWiki's `PROPERTY_GROUP_SCHEMA` validation. An invalid
+	 * file is silently skipped at import time, so the groups would never appear
+	 * on Special:Browse without this guard catching it first.
+	 *
+	 * @dataProvider groupSchemaFileProvider
+	 */
+	public function testGroupSchemaFileIsValid( string $name, string $file ) {
+		$contents = file_get_contents( $file );
+
+		$this->assertIsString( $contents );
+
+		$schemaFactory = new SchemaFactory();
+		$schema = $schemaFactory->newSchema( $name, $contents );
+
+		$this->assertSame(
+			[],
+			$schemaFactory->newSchemaValidator()->validate( $schema ),
+			"$file is not a valid PROPERTY_GROUP_SCHEMA"
+		);
+	}
+
+	/**
+	 * Guards the guard: the pre-3.2 array shape (`group_name`/`properties`) must
+	 * be rejected, otherwise a regression to it would slip past
+	 * testGroupSchemaFileIsValid unnoticed.
+	 */
+	public function testLegacyArrayShapeIsRejected() {
+		$legacy = json_encode( [
+			'type' => 'PROPERTY_GROUP_SCHEMA',
+			'groups' => [
+				[
+					'group_name' => 'Legacy',
+					'properties' => [ '___PAGEID' ],
+				],
+			],
+		] );
+
+		$schemaFactory = new SchemaFactory();
+		$schema = $schemaFactory->newSchema( 'Legacy', $legacy );
+
+		$this->assertNotSame(
+			[],
+			$schemaFactory->newSchemaValidator()->validate( $schema ),
+			'the legacy array-shaped groups must fail validation'
+		);
+	}
+
+	public function groupSchemaFileProvider() {
+		$importDir = __DIR__ . '/../../../data/import';
+		$manifest = json_decode( file_get_contents( "$importDir/sesp.groups.json" ), true );
+
+		$provider = [];
+
+		foreach ( $manifest['import'] as $entry ) {
+			$page = $entry['page'];
+			$provider[$page] = [ $page, $importDir . $entry['contents']['importFrom'] ];
+		}
+
+		return $provider;
+	}
+
+}


### PR DESCRIPTION
## What & why

Adds `GroupSchemaFileIntegrityTest`, an integration test that validates the property-group schema files under `data/import/groups/` against Semantic MediaWiki's `PROPERTY_GROUP_SCHEMA` validation.

This closes a gap surfaced while reviewing #278: an invalid group-schema file (for example a regression to the pre-3.2 `group_name`/`properties` array shape) is **silently skipped** at import time, so the property groups would simply never appear on Special:Browse — with nothing in CI to flag it. Both `exif.group.json` and `extra.group.json` previously had no test coverage.

## How

- Validates **every** file referenced by the `sesp.groups.json` import manifest (data-provider driven, so new group files are covered automatically) using SMW's own `SchemaFactory::newSchema()` + `SchemaValidator::validate()` — the same path the importer uses, so the test tracks SMW's schema automatically rather than hard-coding rules.
- Includes a negative case asserting the legacy array shape is rejected, so the guard is proven to actually catch a regression.

## Verification

- `composer analyze` clean; integration suite green (`OK (78 tests, 166 assertions)`).
- New test: 3 cases pass — `Group:Extra special properties` valid, `Group:Exif special properties` valid, legacy array shape rejected.

Follow-up to #278 (now merged); test-only change, no runtime impact.