### PR TITLE
Use strict semantic versioning for the version number

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,6 @@
 This file contains the RELEASE-NOTES of the **Semantic Extra Special Properties** (a.k.a. SESP) extension.
 
-### 7.0.0-alpha
+### 5.0.0-alpha
 
 Released on TBD.
 
@@ -8,7 +8,6 @@ Released on TBD.
   * MediaWiki 1.43
   * Semantic MediaWiki 7.0
   * PHP 8.1
-* Major version bumped from 4.x to 7.x to realign with Semantic MediaWiki's major version (5.x and 6.x intentionally skipped).
 * fix (Approved Revs): approving or unapproving a revision triggered a fatal error because the integration called a cache method that no longer exists under Semantic MediaWiki 7.0; it now uses the supported cache API.
 * Volatile special properties such as page views, revision ID, number of revisions and user edit counts are now excluded from Semantic MediaWiki's query-dependency detection, avoiding unnecessary re-evaluation of queries that use them.
 * feat: special properties are again grouped by category (user-related, page-related and the various EXIF groups) on Special:Browse and property pages. The underlying property-group schema import had been inactive since 2021, and the EXIF group schema has been migrated to the format required by Semantic MediaWiki 7.0 (#151).

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "7.x-dev"
+			"dev-master": "5.x-dev"
 		}
 	},
 	"config": {

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "SemanticExtraSpecialProperties",
-	"version": "7.0.0-alpha",
+	"version": "5.0.0-alpha",
 	"author": [
 		"Leo Wallentin",
         "James Hong Kong",

--- a/src/Hooks/ApprovedRevsHooks.php
+++ b/src/Hooks/ApprovedRevsHooks.php
@@ -17,7 +17,7 @@ use Wikimedia\ObjectCache\BagOStuff;
  * parameters are left untyped to match its contract.
  *
  * @license GPL-2.0-or-later
- * @since 7.0.0
+ * @since 5.0.0
  */
 class ApprovedRevsHooks {
 
@@ -28,7 +28,7 @@ class ApprovedRevsHooks {
 
 	/**
 	 * @see https://www.mediawiki.org/wiki/Extension:Approved_Revs/Hooks/ApprovedRevsRevisionApproved
-	 * @since 7.0.0
+	 * @since 5.0.0
 	 *
 	 * @param mixed $output
 	 * @param Title $title
@@ -43,7 +43,7 @@ class ApprovedRevsHooks {
 
 	/**
 	 * @see https://www.mediawiki.org/wiki/Extension:Approved_Revs/Hooks/ApprovedRevsRevisionUnapproved
-	 * @since 7.0.0
+	 * @since 5.0.0
 	 *
 	 * @param mixed $output
 	 * @param Title $title

--- a/src/Hooks/ConfigHooks.php
+++ b/src/Hooks/ConfigHooks.php
@@ -7,7 +7,7 @@ namespace SESP\Hooks;
  * initialization.
  *
  * @license GPL-2.0-or-later
- * @since 7.0.0
+ * @since 5.0.0
  */
 class ConfigHooks {
 
@@ -29,7 +29,7 @@ class ConfigHooks {
 
 	/**
 	 * @see https://www.semantic-mediawiki.org/wiki/Hooks/SMW::Settings::BeforeInitializationComplete
-	 * @since 7.0.0
+	 * @since 5.0.0
 	 *
 	 * @param array &$configuration
 	 */

--- a/src/Hooks/PropertyHooks.php
+++ b/src/Hooks/PropertyHooks.php
@@ -13,7 +13,7 @@ use SMW\Store;
  * their values when Semantic MediaWiki stores data.
  *
  * @license GPL-2.0-or-later
- * @since 7.0.0
+ * @since 5.0.0
  */
 class PropertyHooks {
 
@@ -25,7 +25,7 @@ class PropertyHooks {
 
 	/**
 	 * @see https://www.semantic-mediawiki.org/wiki/Hooks/SMW::Property::initProperties
-	 * @since 7.0.0
+	 * @since 5.0.0
 	 */
 	public function onSMW__Property__initProperties( Registry $registry ): bool {
 		return $this->propertyRegistry->register( $registry );
@@ -33,7 +33,7 @@ class PropertyHooks {
 
 	/**
 	 * @see https://www.semantic-mediawiki.org/wiki/Hooks/SMW::SQLStore::AddCustomFixedPropertyTables
-	 * @since 7.0.0
+	 * @since 5.0.0
 	 *
 	 * @param array &$customFixedProperties
 	 * @param array &$fixedPropertyTablePrefix
@@ -52,7 +52,7 @@ class PropertyHooks {
 
 	/**
 	 * @see https://www.semantic-mediawiki.org/wiki/Hooks/SMW::Store::BeforeDataUpdateComplete
-	 * @since 7.0.0
+	 * @since 5.0.0
 	 */
 	public function onSMW__Store__BeforeDataUpdateComplete( Store $store, SemanticData $semanticData ): bool {
 		$this->extraPropertyAnnotator->addAnnotation( $semanticData );

--- a/tests/phpunit/Integration/GroupSchemaFileIntegrityTest.php
+++ b/tests/phpunit/Integration/GroupSchemaFileIntegrityTest.php
@@ -9,7 +9,7 @@ use SMW\Schema\SchemaFactory;
  * @group medium
  *
  * @license GPL-2.0-or-later
- * @since 7.0.0
+ * @since 5.0.0
  */
 class GroupSchemaFileIntegrityTest extends \PHPUnit\Framework\TestCase {
 

--- a/tests/phpunit/Integration/HookRegistrationIntegrityTest.php
+++ b/tests/phpunit/Integration/HookRegistrationIntegrityTest.php
@@ -12,7 +12,7 @@ namespace SESP\Tests\Integration;
  * @coversNothing
  *
  * @license GPL-2.0-or-later
- * @since 7.0.0
+ * @since 5.0.0
  */
 class HookRegistrationIntegrityTest extends \PHPUnit\Framework\TestCase {
 

--- a/tests/phpunit/Unit/Hooks/ApprovedRevsHooksTest.php
+++ b/tests/phpunit/Unit/Hooks/ApprovedRevsHooksTest.php
@@ -11,7 +11,7 @@ use Wikimedia\ObjectCache\BagOStuff;
  * @group semantic-extra-special-properties
  *
  * @license GPL-2.0-or-later
- * @since 7.0.0
+ * @since 5.0.0
  */
 class ApprovedRevsHooksTest extends \PHPUnit\Framework\TestCase {
 

--- a/tests/phpunit/Unit/Hooks/ConfigHooksTest.php
+++ b/tests/phpunit/Unit/Hooks/ConfigHooksTest.php
@@ -9,7 +9,7 @@ use SESP\Hooks\ConfigHooks;
  * @group semantic-extra-special-properties
  *
  * @license GPL-2.0-or-later
- * @since 7.0.0
+ * @since 5.0.0
  */
 class ConfigHooksTest extends \PHPUnit\Framework\TestCase {
 

--- a/tests/phpunit/Unit/Hooks/PropertyHooksTest.php
+++ b/tests/phpunit/Unit/Hooks/PropertyHooksTest.php
@@ -14,7 +14,7 @@ use SMW\Store;
  * @group semantic-extra-special-properties
  *
  * @license GPL-2.0-or-later
- * @since 7.0.0
+ * @since 5.0.0
  */
 class PropertyHooksTest extends \PHPUnit\Framework\TestCase {
 


### PR DESCRIPTION
## Summary

Adopt semantic versioning for the **SemanticExtraSpecialProperties** version number. Versioning the extension independently of Semantic MediaWiki lets it introduce its own breaking changes mid-cycle — between Semantic MediaWiki major releases — instead of holding them to realign its major with the next Semantic MediaWiki major.

This sets the version to the extension's own next major, `5.0.0-alpha` (branch-alias `5.x-dev`), rather than tracking the Semantic MediaWiki major. The `SemanticMediaWiki >= 7.0` requirement (the Semantic MediaWiki version this release targets) is unchanged.

## Changes

- `extension.json`: version → `5.0.0-alpha`
- `composer.json`: `extra.branch-alias.dev-master` → `5.x-dev`
- `RELEASE-NOTES.md`: heading → `5.0.0-alpha`, and drop the note that described the version tracking / mirroring the Semantic MediaWiki major
- `@since 7.0.0` docblocks updated to `@since 5.0.0` where present
