### PR TITLE
Add _DESCRIPTION special property (page description)

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -12,6 +12,7 @@ Released on TBD.
 * fix (Approved Revs): approving or unapproving a revision triggered a fatal error because the integration called a cache method that no longer exists under Semantic MediaWiki 7.0; it now uses the supported cache API.
 * Volatile special properties such as page views, revision ID, number of revisions and user edit counts are now excluded from Semantic MediaWiki's query-dependency detection, avoiding unnecessary re-evaluation of queries that use them.
 * feat: special properties are again grouped by category (user-related, page-related and the various EXIF groups) on Special:Browse and property pages. The underlying property-group schema import had been inactive since 2021, and the EXIF group schema has been migrated to the format required by Semantic MediaWiki 7.0 (#151).
+* feat: new special property `_DESCRIPTION` ("Description of the page") which records the page's `description` page property, as set by meta-description extensions such as [Description2](https://www.mediawiki.org/wiki/Extension:Description2) or [WikiSEO](https://www.mediawiki.org/wiki/Extension:WikiSEO). It is read regardless of which extension set it, and stays empty when none has (#205).
 
 ### 4.0.0
 

--- a/data/definitions.json
+++ b/data/definitions.json
@@ -51,6 +51,13 @@
 		"alias": "sesp-property-view-count",
 		"label": "Number of page views"
 	},
+	"_DESCRIPTION": {
+		"id": "___DESCRIPTION",
+		"type": "_txt",
+		"show": false,
+		"alias": "sesp-property-description",
+		"label": "Description of the page"
+	},
 	"_NSID": {
 		"id": "___NSID",
 		"type": "_num",

--- a/data/import/groups/extra.group.json
+++ b/data/import/groups/extra.group.json
@@ -27,6 +27,7 @@
                 "___EUSER",
                 "___CUSER",
                 "___VIEWS",
+                "___DESCRIPTION",
                 "___SUBP",
                 "___NREV",
                 "___NTREV",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,6 +48,7 @@ Property labels differ according to the language the wiki was set up. An easy wa
 - `_APPROVEDDATE` adds a property called "Approved date" which records the date a page was approved if the [Approved Revs][Approved Revs] extension is installed
 - `_APPROVEDSTATUS` adds a property called "Approval status" which records the approvement status of a page if the [Approved Revs][Approved Revs] extension is installed
 - `_PAGEIMG` adds a property called "Page Images" which records PageImages of a page if the [PageImages][PageImages] extension is installed
+- `_DESCRIPTION` adds a property called "Description of the page" which records the page's `description` page property, as set by meta-description extensions such as [Description2][Description2] or [WikiSEO][WikiSEO]. It is read regardless of which extension set it, and stays empty when none has
 
 ## Additional configuration
 
@@ -111,3 +112,5 @@ a [privacy issue][privacy].
 [mw-localsettings]: https://www.mediawiki.org/wiki/Localsettings
 [mw-contentlang]: https://www.mediawiki.org/wiki/Content_language
 [PageImages]: https://www.mediawiki.org/wiki/Extension:PageImages
+[Description2]: https://www.mediawiki.org/wiki/Extension:Description2
+[WikiSEO]: https://www.mediawiki.org/wiki/Extension:WikiSEO

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -23,6 +23,8 @@
 	"sesp-property-page-img-desc": "\"$1\" records the PageImages (Extension:PageImages) of a page . It is is provided by the [https://www.semantic-mediawiki.org/wiki/Extension:Semantic_Extra_Special_Properties Semantic Extra Special Properties] extension.",
 	"sesp-property-view-count": "Number of page views",
 	"sesp-property-view-count-desc": "\"$1\" records the number of page views of a page. It is provided by the [https://www.semantic-mediawiki.org/wiki/Extension:Semantic_Extra_Special_Properties Semantic Extra Special Properties] extension.",
+	"sesp-property-description": "Description of the page",
+	"sesp-property-description-desc": "\"$1\" records a page's description, as stored in the \"description\" page property by meta-description extensions such as Description2 or WikiSEO. It is read regardless of which extension set it. It is provided by the [https://www.semantic-mediawiki.org/wiki/Extension:Semantic_Extra_Special_Properties Semantic Extra Special Properties] extension.",
 	"sesp-property-subpages": "Subpage",
 	"sesp-property-subpages-desc": "\"$1\" records all subpages of a page. It is provided by the [https://www.semantic-mediawiki.org/wiki/Extension:Semantic_Extra_Special_Properties Semantic Extra Special Properties] extension.",
 	"sesp-property-revisions": "Number of revisions",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -31,6 +31,8 @@
 	"sesp-property-page-img-desc": "« $1 » enregistre les images de page (Extension:PageImages) pour une page donnée. Ceci est fourni par l’extension [https://www.semantic-mediawiki.org/wiki/Extension:Semantic_Extra_Special_Properties Propriétés sémantiques spéciales complémentaires].",
 	"sesp-property-view-count": "Nombre de vues de la page",
 	"sesp-property-view-count-desc": "« $1 » enregistre le nombre de consultations d’une page. Ceci est fourni par l’extension [https://www.semantic-mediawiki.org/wiki/Extension:Semantic_Extra_Special_Properties Propriétés sémantiques spéciales complémentaires].",
+	"sesp-property-description": "Description de la page",
+	"sesp-property-description-desc": "« $1 » enregistre la description d’une page, telle que stockée dans la propriété de page « description » par des extensions de méta-description comme Description2 ou WikiSEO. Elle est lue quelle que soit l’extension qui l’a définie. Ceci est fourni par l’extension [https://www.semantic-mediawiki.org/wiki/Extension:Semantic_Extra_Special_Properties Propriétés sémantiques spéciales complémentaires].",
 	"sesp-property-subpages": "Sous-page",
 	"sesp-property-subpages-desc": "« $1 » enregistre toutes les sous-pages d’une page. Ceci est fourni par l’extension [https://www.semantic-mediawiki.org/wiki/Extension:Semantic_Extra_Special_Properties Propriétés sémantiques spéciales complémentaires].",
 	"sesp-property-revisions": "Nombre de révisions",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -27,6 +27,8 @@
 	"sesp-property-page-img-desc": "{{Doc-smw-sp-desc|extension=SESP}}",
 	"sesp-property-view-count": "{{Doc-smw-sp|extension=SESP}}",
 	"sesp-property-view-count-desc": "{{Doc-smw-sp-desc|extension=SESP}}",
+	"sesp-property-description": "{{Doc-smw-sp|extension=SESP}}",
+	"sesp-property-description-desc": "{{Doc-smw-sp-desc|extension=SESP}}",
 	"sesp-property-subpages": "{{Doc-smw-sp|extension=SESP}}\n{{Identical|Subpage}}",
 	"sesp-property-subpages-desc": "{{Doc-smw-sp-desc|extension=SESP}}",
 	"sesp-property-revisions": "{{Doc-smw-sp|extension=SESP}}",

--- a/src/AppFactory.php
+++ b/src/AppFactory.php
@@ -173,6 +173,27 @@ class AppFactory implements LoggerAwareInterface {
 	}
 
 	/**
+	 * Reads a single page property as persisted in the `page_props` table (for
+	 * example the `description` set by the Description2 extension).
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param Title $title
+	 * @param string $name
+	 *
+	 * @return string|null the property value, or null when it is not set
+	 */
+	public function getPageProperty( Title $title, string $name ): ?string {
+		$properties = MediaWikiServices::getInstance()->getPageProps()->getProperties( $title, $name );
+
+		if ( $properties === [] ) {
+			return null;
+		}
+
+		return (string)reset( $properties );
+	}
+
+	/**
 	 * @since 1.3
 	 *
 	 * @param Title $title

--- a/src/PropertyAnnotators/DispatchingPropertyAnnotator.php
+++ b/src/PropertyAnnotators/DispatchingPropertyAnnotator.php
@@ -106,6 +106,10 @@ class DispatchingPropertyAnnotator implements PropertyAnnotator {
 				return new PageViewsPropertyAnnotator( $appFactory );
 			},
 
+			PageDescriptionPropertyAnnotator::PROP_ID => static function ( $appFactory ) {
+				return new PageDescriptionPropertyAnnotator( $appFactory );
+			},
+
 			NamespacePropertyAnnotator::PROP_ID => static function ( $appFactory ) {
 				return new NamespacePropertyAnnotator( $appFactory );
 			},

--- a/src/PropertyAnnotators/PageDescriptionPropertyAnnotator.php
+++ b/src/PropertyAnnotators/PageDescriptionPropertyAnnotator.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace SESP\PropertyAnnotators;
+
+use SESP\AppFactory;
+use SESP\PropertyAnnotator;
+use SMW\DataItems\Blob;
+use SMW\DataItems\Property;
+use SMW\DataModel\SemanticData;
+
+/**
+ * Annotates a page with its description, read from the `description` page
+ * property. That property is written by meta-description extensions such as
+ * Description2 and WikiSEO; this annotator reads it regardless of the writer
+ * and leaves the annotation empty when no such page property is present, so
+ * there is no hard dependency on any particular extension.
+ *
+ * @private
+ * @ingroup SESP
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+class PageDescriptionPropertyAnnotator implements PropertyAnnotator {
+
+	/**
+	 * Predefined property ID
+	 */
+	public const PROP_ID = '___DESCRIPTION';
+
+	public function __construct(
+		private readonly AppFactory $appFactory
+	) {
+	}
+
+	/**
+	 * @since 7.0.0
+	 *
+	 * {@inheritDoc}
+	 */
+	public function isAnnotatorFor( Property $property ) {
+		return $property->getKey() === self::PROP_ID;
+	}
+
+	/**
+	 * @since 7.0.0
+	 *
+	 * {@inheritDoc}
+	 */
+	public function addAnnotation( Property $property, SemanticData $semanticData ) {
+		$description = $this->appFactory->getPageProperty(
+			$semanticData->getSubject()->getTitle(),
+			'description'
+		);
+
+		if ( $description !== null && $description !== '' ) {
+			$semanticData->addPropertyObjectValue( $property, new Blob( $description ) );
+		}
+	}
+
+}

--- a/tests/phpunit/Unit/AppFactoryTest.php
+++ b/tests/phpunit/Unit/AppFactoryTest.php
@@ -84,6 +84,16 @@ class AppFactoryTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
+	public function testGetPagePropertyReturnsNullForUnknownPage() {
+		$title = Title::newFromText( 'SESP-getPageProperty-unknown-page' );
+
+		$instance = new AppFactory();
+
+		$this->assertNull(
+			$instance->getPageProperty( $title, 'description' )
+		);
+	}
+
 	public function testGetConnection() {
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/PropertyAnnotators/DispatchingPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/DispatchingPropertyAnnotatorTest.php
@@ -15,6 +15,7 @@ use SESP\PropertyAnnotators\NamespaceNamePropertyAnnotator;
 use SESP\PropertyAnnotators\NamespacePropertyAnnotator;
 use SESP\PropertyAnnotators\NullPropertyAnnotator;
 use SESP\PropertyAnnotators\PageContributorsPropertyAnnotator;
+use SESP\PropertyAnnotators\PageDescriptionPropertyAnnotator;
 use SESP\PropertyAnnotators\PageIDPropertyAnnotator;
 use SESP\PropertyAnnotators\PageImagesPropertyAnnotator;
 use SESP\PropertyAnnotators\PageLengthPropertyAnnotator;
@@ -118,6 +119,11 @@ class DispatchingPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 		$provider[] = [
 			PageViewsPropertyAnnotator::PROP_ID,
 			PageViewsPropertyAnnotator::class
+		];
+
+		$provider[] = [
+			PageDescriptionPropertyAnnotator::PROP_ID,
+			PageDescriptionPropertyAnnotator::class
 		];
 
 		$provider[] = [

--- a/tests/phpunit/Unit/PropertyAnnotators/PageDescriptionPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/PageDescriptionPropertyAnnotatorTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace SESP\Tests\PropertyAnnotators;
+
+use SESP\AppFactory;
+use SESP\PropertyAnnotators\PageDescriptionPropertyAnnotator;
+use SMW\DataItems\Property;
+use SMW\DataItems\WikiPage as DIWikiPage;
+use SMW\DataModel\SemanticData;
+
+/**
+ * @covers \SESP\PropertyAnnotators\PageDescriptionPropertyAnnotator
+ * @group semantic-extra-special-properties
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+class PageDescriptionPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
+
+	private $property;
+	private $appFactory;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->appFactory = $this->getMockBuilder( AppFactory::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->property = new Property( '___DESCRIPTION' );
+	}
+
+	public function testCanConstruct() {
+		$this->assertInstanceOf(
+			PageDescriptionPropertyAnnotator::class,
+			new PageDescriptionPropertyAnnotator( $this->appFactory )
+		);
+	}
+
+	public function testIsAnnotatorFor() {
+		$instance = new PageDescriptionPropertyAnnotator(
+			$this->appFactory
+		);
+
+		$this->assertTrue(
+			$instance->isAnnotatorFor( $this->property )
+		);
+	}
+
+	public function testAddAnnotation() {
+		$subject = DIWikiPage::newFromText( __METHOD__ );
+
+		$this->appFactory->expects( $this->once() )
+			->method( 'getPageProperty' )
+			->with( $this->anything(), 'description' )
+			->willReturn( 'A short summary of the page.' );
+
+		$semanticData = $this->getMockBuilder( SemanticData::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->once() )
+			->method( 'getSubject' )
+			->willReturn( $subject );
+
+		$semanticData->expects( $this->once() )
+			->method( 'addPropertyObjectValue' );
+
+		$instance = new PageDescriptionPropertyAnnotator(
+			$this->appFactory
+		);
+
+		$instance->addAnnotation( $this->property, $semanticData );
+	}
+
+	public function testAddAnnotationIsSkippedWhenNoDescription() {
+		$subject = DIWikiPage::newFromText( __METHOD__ );
+
+		$this->appFactory->expects( $this->once() )
+			->method( 'getPageProperty' )
+			->willReturn( null );
+
+		$semanticData = $this->getMockBuilder( SemanticData::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->once() )
+			->method( 'getSubject' )
+			->willReturn( $subject );
+
+		$semanticData->expects( $this->never() )
+			->method( 'addPropertyObjectValue' );
+
+		$instance = new PageDescriptionPropertyAnnotator(
+			$this->appFactory
+		);
+
+		$instance->addAnnotation( $this->property, $semanticData );
+	}
+
+}


### PR DESCRIPTION
## What & why

Adds a new special property **`_DESCRIPTION`** ("Description of the page") that records a page's `description` page property. Enable it via `$sespgEnabledPropertyList` like any other SESP property.

`description` is a shared MediaWiki page-property convention written by meta-description extensions — confirmed writers include **[Description2](https://www.mediawiki.org/wiki/Extension:Description2)** (the original/canonical writer, via `setPageProperty('description', …)`) and **[WikiSEO](https://www.mediawiki.org/wiki/Extension:WikiSEO)** (writes the same key). SESP reads it **regardless of which extension set it**, and the property stays empty when none has — so there is no hard dependency on any particular extension.

This is a from-scratch reimplementation, against the current Semantic MediaWiki 7.0 architecture, of the feature proposed in #205 by @bertrandgorge (credited as co-author). #205 itself could not be merged: it edited files removed in the 7.0 refactor (`src/HookRegistry.php`) and relied on `SMWDIString` and `ParserOutput::getProperty()`, both removed from the current stack.

## How

- **`PageDescriptionPropertyAnnotator`** — annotates `___DESCRIPTION` with a `Blob` (the `_txt` data item) when a description is present. Source-agnostic: it reads the `description` page_props entry whatever extension wrote it.
- **Reads from `page_props`, not a re-parse.** A new `AppFactory::getPageProperty()` helper reads the persisted `description` page property via MediaWiki's `PageProps` service, so no parse is forced during the SMW data update. (The original #205 called `getParserOutput()` on every update; this avoids that cost.)
- Wired through `DispatchingPropertyAnnotator`, `data/definitions.json` (`type: _txt`, `show: false`), the page-related group in `data/import/groups/extra.group.json`, the `en`/`fr`/`qqq` messages, and `docs/configuration.md`.
- **Not** added to the query-dependency exemption list: a description is content-derived (changes only on a deliberate edit), so queries on it should track dependencies — unlike the volatile byproduct properties that list is scoped to.

## Verification

- `composer analyze` clean (lint + PHPCS, no errors/warnings); `composer phpunit` green — `OK (290 tests, 620 assertions)`, including new annotator tests and an `AppFactory::getPageProperty` test.
- End-to-end on a freshly installed wiki (MW 1.43, SMW dev-master): seeding a `description` page property and running the annotator yields the expected `SMW\DataItems\Blob` value on the subject.

Closes #205 (superseded).