### PR TITLE
Handle multi-valued EXIF/XMP date values

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,11 @@
 This file contains the RELEASE-NOTES of the **Semantic Extra Special Properties** (a.k.a. SESP) extension.
 
+### 5.0.1
+
+Released on TBD.
+
+* Fixed a fatal error that aborted a page's entire Semantic MediaWiki data update when an EXIF or XMP date property held a multi-valued value, such as an XMP `dc:date` Dublin Core sequence; such values are now handled (#226).
+
 ### 5.0.0
 
 Released on June 8, 2026.

--- a/src/PropertyAnnotators/ExifPropertyAnnotator.php
+++ b/src/PropertyAnnotators/ExifPropertyAnnotator.php
@@ -177,6 +177,15 @@ class ExifPropertyAnnotator implements PropertyAnnotator {
 	}
 
 	private function makeDataItemTime( $exifValue ) {
+		if ( is_array( $exifValue ) ) {
+			unset( $exifValue['_type'] );
+			$exifValue = $exifValue !== [] ? reset( $exifValue ) : null;
+		}
+
+		if ( !is_string( $exifValue ) ) {
+			return null;
+		}
+
 		try {
 			$datetime = $this->convertExifDate( $exifValue );
 		} catch ( \Exception $e ) {

--- a/tests/phpunit/Unit/PropertyAnnotators/ExifPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ExifPropertyAnnotatorTest.php
@@ -226,6 +226,13 @@ class ExifPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			$this->once()
 		];
 
+		// #226 - empty once _type is dropped: no annotation, no fatal
+		$provider['multivalue-empty'] = [
+			[ 'dc-date' => [ '_type' => 'ol' ] ],
+			[ '_EXIF' => [ 'DC-DATE' => [ 'id' => 'Foo', 'type' => '_dat' ] ] ],
+			$this->never()
+		];
+
 		return $provider;
 	}
 

--- a/tests/phpunit/Unit/PropertyAnnotators/ExifPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ExifPropertyAnnotatorTest.php
@@ -219,6 +219,13 @@ class ExifPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 			$this->never()
 		];
 
+		// #226
+		$provider['multivalue-dc-date'] = [
+			[ 'dc-date' => [ 0 => '2025:11:03 21:27:42', '_type' => 'ol' ] ],
+			[ '_EXIF' => [ 'DC-DATE' => [ 'id' => 'Foo', 'type' => '_dat' ] ] ],
+			$this->once()
+		];
+
 		return $provider;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/SemanticMediaWiki/SemanticExtraSpecialProperties/issues/226

An XMP `dc:date` is a Dublin Core sequence, so MediaWiki stores it as an array like `[ 0 => '2025:11:03 21:27:42', '_type' => 'ol' ]` rather than a scalar string. `ExifPropertyAnnotator` maps `dc-date` to an Exif `_dat` property and passed the raw value straight into `preg_match()`, which threw an uncaught `TypeError` (a PHP `Error`, so the surrounding `catch ( \Exception )` did not catch it) and aborted the page's whole SMW data update.

`makeDataItemTime()` now collapses a multi-valued date to its first element before parsing, then guards against non-string shapes so any unexpected value yields no annotation instead of a fatal.

Extracting the first value, rather than only broadening the caught type, preserves the date instead of silently discarding it; taking the first element mirrors how MediaWiki itself reduces a multi-value to a single value in `FormatMetadata::resolveMultivalueValue()`.

### Tests
`ExifPropertyAnnotatorTest::metaProvider` gains a `multivalue-dc-date` case: a `dc-date` stored as `[ 0 => '2025:11:03 21:27:42', '_type' => 'ol' ]`, expecting the annotation to be added. It errors with the `TypeError` on the current code and passes with the fix.

<sub>AI-authored: Claude Code, `Opus 4.8`; root-caused and fixed for @malberts, with the approach and the diff reviewed by @malberts over several rounds (including the explicit-guard revision). Verified locally on a clean MediaWiki 1.43.9 / Semantic MediaWiki 7.2 / SESP 5.0.0 install (PHP 8.3.31, PHPUnit 9.6): the `multivalue-dc-date` test errors with the `TypeError` on the unpatched code and passes with the fix; the later explicit-empty-check guard is behaviour-identical and is run by the PR's CI.</sub>
